### PR TITLE
Move test reporting from main

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1,13 +1,6 @@
 #include "tests.hpp"
-#include "game_data.hpp"
-#include <iostream>
 
 
 int main() {
-    if (test_game_data() != 0) {
-        std::cerr << "Tests failed" << std::endl;
-        return 1;
-    }
-    std::cout << "All tests passed" << std::endl;
-    return 0;
+    return run_all_tests_with_report();
 }

--- a/tests.cpp
+++ b/tests.cpp
@@ -32,3 +32,65 @@ int test_game_data() {
     }
     return 0;
 }
+
+int test_wrap_around_edges() {
+    game_data gd(2, 2);
+    if (gd._error)
+        return 1;
+    gd._wrap_around_edges = 1;
+    gd._map.set(1, 0, 2, SNAKE_HEAD_PLAYER_1);
+    gd._direction_moving[0] = DIRECTION_RIGHT;
+    if (gd.update_snake_position(SNAKE_HEAD_PLAYER_1))
+        return 1;
+    t_coordinates head = gd.get_head_coordinate(SNAKE_HEAD_PLAYER_1);
+    if (head.x != 0 || head.y != 0)
+        return 1;
+    return 0;
+}
+
+int test_invalid_move_wall() {
+    game_data gd(2, 2);
+    if (gd._error)
+        return 1;
+    gd._map.set(1, 0, 0, GAME_TILE_WALL);
+    gd._map.set(0, 0, 2, SNAKE_HEAD_PLAYER_1);
+    gd._direction_moving[0] = DIRECTION_RIGHT;
+    if (gd.is_valid_move(SNAKE_HEAD_PLAYER_1) == 0)
+        return 1;
+    if (gd.update_snake_position(SNAKE_HEAD_PLAYER_1) == 0)
+        return 1;
+    return 0;
+}
+
+int test_self_collision() {
+    game_data gd(3, 1);
+    if (gd._error)
+        return 1;
+    gd._map.set(1, 0, 2, SNAKE_HEAD_PLAYER_1);
+    gd._map.set(0, 0, 2, SNAKE_HEAD_PLAYER_1 + 1);
+    gd._direction_moving[0] = DIRECTION_LEFT;
+    if (gd.is_valid_move(SNAKE_HEAD_PLAYER_1) == 0)
+        return 1;
+    if (gd.update_snake_position(SNAKE_HEAD_PLAYER_1) == 0)
+        return 1;
+    return 0;
+}
+
+int run_all_tests() {
+    int failed = 0;
+    failed += test_game_data();
+    failed += test_wrap_around_edges();
+    failed += test_invalid_move_wall();
+    failed += test_self_collision();
+    return failed;
+}
+
+int run_all_tests_with_report() {
+    int failed = run_all_tests();
+    if (failed != 0) {
+        std::cerr << "Tests failed" << std::endl;
+    } else {
+        std::cout << "All tests passed" << std::endl;
+    }
+    return failed;
+}

--- a/tests.hpp
+++ b/tests.hpp
@@ -2,5 +2,10 @@
 #define TESTS_HPP
 
 int test_game_data();
+int test_wrap_around_edges();
+int test_invalid_move_wall();
+int test_self_collision();
+int run_all_tests();
+int run_all_tests_with_report();
 
 #endif


### PR DESCRIPTION
## Summary
- trim down `main.cpp` to just invoke tests
- add `run_all_tests_with_report` to handle pass/fail output

## Testing
- `make`
- `./dnd_tools`


------
https://chatgpt.com/codex/tasks/task_e_688a0329cf888331bbad12c42fffeef1