### PR TITLE
Add board reset and resize features

### DIFF
--- a/game_data.cpp
+++ b/game_data.cpp
@@ -10,14 +10,15 @@ game_data::game_data(int width, int height) :
 		this->_error = this->_map.get_error();
 	else if (this->_character.get_error())
 		this->_error = this->_character.get_error();
-	int index = 0;
-	while (index < 4)
-	{
-		this->_direction_moving_ice[index] = 0;
-		this->_direction_moving[index] = 0;
-		index++;
-	}
-	return ;
+        int index = 0;
+        while (index < 4)
+        {
+                this->_direction_moving_ice[index] = 0;
+                this->_direction_moving[index] = 0;
+                index++;
+        }
+        this->reset_board();
+        return ;
 }
 
 t_coordinates game_data::get_head_coordinate(int head_to_find)
@@ -236,5 +237,39 @@ int     game_data::update_snake_position(int player_head)
     }
     this->_map.set(target_x, target_y, 2, offset + 1);
     return (0);
+}
+
+void game_data::reset_board()
+{
+    for (size_t y = 0; y < this->_map.get_height(); ++y)
+    {
+        for (size_t x = 0; x < this->_map.get_width(); ++x)
+        {
+            this->_map.set(x, y, 0, GAME_TILE_EMPTY);
+            this->_map.set(x, y, 1, 0);
+            this->_map.set(x, y, 2, 0);
+        }
+    }
+    for (int i = 0; i < 4; ++i)
+    {
+        this->_direction_moving[i] = 0;
+        this->_direction_moving_ice[i] = 0;
+    }
+    this->_amount_players_dead = 0;
+    int mid_x = static_cast<int>(this->_map.get_width() / 2);
+    int mid_y = static_cast<int>(this->_map.get_height() / 2);
+    this->_map.set(mid_x, mid_y, 2, SNAKE_HEAD_PLAYER_1);
+}
+
+void game_data::resize_board(int width, int height)
+{
+    ft_map3d new_map(width, height, 3);
+    if (new_map.get_error())
+    {
+        this->_error = new_map.get_error();
+        return;
+    }
+    this->_map = new_map;
+    this->reset_board();
 }
 

--- a/game_data.hpp
+++ b/game_data.hpp
@@ -30,6 +30,8 @@ class game_data
 {
         public:
                 game_data(int width, int height);
+                void                    reset_board();
+                void                    resize_board(int width, int height);
 		mutable int		_error;
 		int				_wrap_around_edges;
 		int				_amount_players_dead;

--- a/tests.cpp
+++ b/tests.cpp
@@ -76,12 +76,38 @@ int test_self_collision() {
     return 0;
 }
 
+int test_reset_board() {
+    game_data gd(5, 5);
+    if (gd._error)
+        return 1;
+    gd.reset_board();
+    t_coordinates head = gd.get_head_coordinate(SNAKE_HEAD_PLAYER_1);
+    if (head.x != 2 || head.y != 2)
+        return 1;
+    return 0;
+}
+
+int test_resize_board() {
+    game_data gd(3, 3);
+    if (gd._error)
+        return 1;
+    gd.resize_board(4, 4);
+    if (gd._map.get_width() != 4 || gd._map.get_height() != 4)
+        return 1;
+    t_coordinates head = gd.get_head_coordinate(SNAKE_HEAD_PLAYER_1);
+    if (head.x != 2 || head.y != 2)
+        return 1;
+    return 0;
+}
+
 int run_all_tests() {
     int failed = 0;
     failed += test_game_data();
     failed += test_wrap_around_edges();
     failed += test_invalid_move_wall();
     failed += test_self_collision();
+    failed += test_reset_board();
+    failed += test_resize_board();
     return failed;
 }
 
@@ -94,6 +120,8 @@ int run_all_tests_with_report() {
         {"test_wrap_around_edges", test_wrap_around_edges},
         {"test_invalid_move_wall", test_invalid_move_wall},
         {"test_self_collision", test_self_collision},
+        {"test_reset_board", test_reset_board},
+        {"test_resize_board", test_resize_board},
     };
 
     int failed = 0;

--- a/tests.hpp
+++ b/tests.hpp
@@ -5,6 +5,8 @@ int test_game_data();
 int test_wrap_around_edges();
 int test_invalid_move_wall();
 int test_self_collision();
+int test_reset_board();
+int test_resize_board();
 int run_all_tests();
 int run_all_tests_with_report();
 


### PR DESCRIPTION
## Summary
- add ability to reset and resize the board
- reset and resize place the snake in the centre
- test new board features

## Testing
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_688a129ab984833192ca0fd92abcbfd7