### PR TITLE
Encapsulate game data and expose map updates

### DIFF
--- a/game_data.cpp
+++ b/game_data.cpp
@@ -3,7 +3,7 @@
 #include "libft/Game/map3d.hpp"
 
 game_data::game_data(int width, int height) :
-	_error(0), _wrap_around_edges(0), _amount_players_dead(0),
+        _error(0), _wrap_around_edges(0), _amount_players_dead(0),
         _map(width, height, 3), _character()
 {
 	if (this->_map.get_error())
@@ -19,6 +19,54 @@ game_data::game_data(int width, int height) :
         }
         this->reset_board();
         return ;
+}
+
+int game_data::get_error() const
+{
+    return this->_error;
+}
+
+void game_data::set_wrap_around_edges(int value)
+{
+    this->_wrap_around_edges = value;
+}
+
+int game_data::get_wrap_around_edges() const
+{
+    return this->_wrap_around_edges;
+}
+
+void game_data::set_direction_moving(int player, int direction)
+{
+    if (player >= 0 && player < 4)
+        this->_direction_moving[player] = direction;
+}
+
+int game_data::get_direction_moving(int player) const
+{
+    if (player >= 0 && player < 4)
+        return this->_direction_moving[player];
+    return 0;
+}
+
+void game_data::set_map_value(int x, int y, int layer, int value)
+{
+    this->_map.set(x, y, layer, value);
+}
+
+int game_data::get_map_value(int x, int y, int layer) const
+{
+    return this->_map.get(x, y, layer);
+}
+
+size_t game_data::get_width() const
+{
+    return this->_map.get_width();
+}
+
+size_t game_data::get_height() const
+{
+    return this->_map.get_height();
 }
 
 t_coordinates game_data::get_head_coordinate(int head_to_find)

--- a/game_data.hpp
+++ b/game_data.hpp
@@ -22,34 +22,43 @@ static const int MAX_SNAKE_LENGTH = 40000;
 
 typedef struct s_coordinates
 {
-	int x;
-	int y;
+    int x;
+    int y;
 } t_coordinates;
 
 class game_data
 {
-        public:
-            game_data(int width, int height);
-            void reset_board();
-            void resize_board(int width, int height);
+public:
+    game_data(int width, int height);
+    void reset_board();
+    void resize_board(int width, int height);
 
-			mutable int		_error;
-			int				_wrap_around_edges;
-			int				_amount_players_dead;
-			int				_direction_moving[4];
-			int				_direction_moving_ice[4];
+    int  get_error() const;
+    void set_wrap_around_edges(int value);
+    int  get_wrap_around_edges() const;
+    void set_direction_moving(int player, int direction);
+    int  get_direction_moving(int player) const;
 
-			ft_map3d		_map;
-			ft_character	_character;
+    void   set_map_value(int x, int y, int layer, int value);
+    int    get_map_value(int x, int y, int layer) const;
+    size_t get_width() const;
+    size_t get_height() const;
 
-			t_coordinates 	get_head_coordinate(int head_to_find);
-			int				is_valid_move(int player_head);
-			int				update_snake_position(int player_head);
-			int				determine_player_number(int player_head);
+    t_coordinates get_head_coordinate(int head_to_find);
+    int           is_valid_move(int player_head);
+    int           update_snake_position(int player_head);
+    int           update_game_map();
 
-			t_coordinates	get_next_piece(t_coordinates current_coordinate,
-								int piece_id);
+private:
+    t_coordinates get_next_piece(t_coordinates current_coordinate, int piece_id);
+    int           determine_player_number(int player_head);
 
-	private:
-			int	update_game_map();
+    mutable int _error;
+    int         _wrap_around_edges;
+    int         _amount_players_dead;
+    int         _direction_moving[4];
+    int         _direction_moving_ice[4];
+
+    ft_map3d     _map;
+    ft_character _character;
 };

--- a/tests.cpp
+++ b/tests.cpp
@@ -6,12 +6,12 @@
 static void print_layer(const game_data &gd)
 {
     size_t y = 0;
-    while (y < gd._map.get_height())
+    while (y < gd.get_height())
     {
         size_t x = 0;
-        while (x < gd._map.get_width())
+        while (x < gd.get_width())
         {
-            std::cout << std::setw(8) << gd._map.get(x, y, 2);
+            std::cout << std::setw(8) << gd.get_map_value(static_cast<int>(x), static_cast<int>(y), 2);
             ++x;
         }
         std::cout << "\n";
@@ -19,18 +19,18 @@ static void print_layer(const game_data &gd)
     }
 }
 
-int test_game_data()
+static int test_game_data()
 {
     game_data gd(3, 3);
-    if (gd._error)
-	{
-        std::cerr << "Initialization error: " << gd._error << std::endl;
+    if (gd.get_error())
+    {
+        std::cerr << "Initialization error: " << gd.get_error() << std::endl;
         return 1;
     }
-    gd._map.set(0, 0, 2, SNAKE_HEAD_PLAYER_1);
-    gd._direction_moving[0] = DIRECTION_RIGHT;
-    if (gd.update_snake_position(SNAKE_HEAD_PLAYER_1))
-	{
+    gd.set_map_value(0, 0, 2, SNAKE_HEAD_PLAYER_1);
+    gd.set_direction_moving(0, DIRECTION_RIGHT);
+    if (gd.update_game_map())
+    {
         std::cerr << "Update failed" << std::endl;
         return 1;
     }
@@ -45,15 +45,15 @@ int test_game_data()
     return 0;
 }
 
-int test_wrap_around_edges()
+static int test_wrap_around_edges()
 {
     game_data gd(2, 2);
-    if (gd._error)
+    if (gd.get_error())
         return 1;
-    gd._wrap_around_edges = 1;
-    gd._map.set(1, 0, 2, SNAKE_HEAD_PLAYER_1);
-    gd._direction_moving[0] = DIRECTION_RIGHT;
-    if (gd.update_snake_position(SNAKE_HEAD_PLAYER_1))
+    gd.set_wrap_around_edges(1);
+    gd.set_map_value(1, 0, 2, SNAKE_HEAD_PLAYER_1);
+    gd.set_direction_moving(0, DIRECTION_RIGHT);
+    if (gd.update_game_map())
         return 1;
     t_coordinates head = gd.get_head_coordinate(SNAKE_HEAD_PLAYER_1);
     if (head.x != 0 || head.y != 0)
@@ -61,39 +61,39 @@ int test_wrap_around_edges()
     return 0;
 }
 
-int test_invalid_move_wall()
+static int test_invalid_move_wall()
 {
     game_data gd(2, 2);
-    if (gd._error)
+    if (gd.get_error())
         return 1;
-    gd._map.set(1, 0, 0, GAME_TILE_WALL);
-    gd._map.set(0, 0, 2, SNAKE_HEAD_PLAYER_1);
-    gd._direction_moving[0] = DIRECTION_RIGHT;
+    gd.set_map_value(1, 0, 0, GAME_TILE_WALL);
+    gd.set_map_value(0, 0, 2, SNAKE_HEAD_PLAYER_1);
+    gd.set_direction_moving(0, DIRECTION_RIGHT);
     if (gd.is_valid_move(SNAKE_HEAD_PLAYER_1) == 0)
         return 1;
-    if (gd.update_snake_position(SNAKE_HEAD_PLAYER_1) == 0)
+    if (gd.update_game_map() == 0)
         return 1;
     return 0;
 }
 
-int test_self_collision()
+static int test_self_collision()
 {
     game_data gd(3, 1);
-    if (gd._error)
+    if (gd.get_error())
         return 1;
-    gd._map.set(1, 0, 2, SNAKE_HEAD_PLAYER_1);
-    gd._map.set(0, 0, 2, SNAKE_HEAD_PLAYER_1 + 1);
-    gd._direction_moving[0] = DIRECTION_LEFT;
+    gd.set_map_value(1, 0, 2, SNAKE_HEAD_PLAYER_1);
+    gd.set_map_value(0, 0, 2, SNAKE_HEAD_PLAYER_1 + 1);
+    gd.set_direction_moving(0, DIRECTION_LEFT);
     if (gd.is_valid_move(SNAKE_HEAD_PLAYER_1) == 0)
         return 1;
-    if (gd.update_snake_position(SNAKE_HEAD_PLAYER_1) == 0)
+    if (gd.update_game_map() == 0)
         return 1;
     return 0;
 }
 
-int test_reset_board() {
+static int test_reset_board() {
     game_data gd(5, 5);
-    if (gd._error)
+    if (gd.get_error())
         return 1;
     gd.reset_board();
     t_coordinates head = gd.get_head_coordinate(SNAKE_HEAD_PLAYER_1);
@@ -102,28 +102,17 @@ int test_reset_board() {
     return 0;
 }
 
-int test_resize_board() {
+static int test_resize_board() {
     game_data gd(3, 3);
-    if (gd._error)
+    if (gd.get_error())
         return 1;
     gd.resize_board(4, 4);
-    if (gd._map.get_width() != 4 || gd._map.get_height() != 4)
+    if (gd.get_width() != 4 || gd.get_height() != 4)
         return 1;
     t_coordinates head = gd.get_head_coordinate(SNAKE_HEAD_PLAYER_1);
     if (head.x != 2 || head.y != 2)
         return 1;
     return 0;
-}
-
-int run_all_tests() {
-    int failed = 0;
-    failed += test_game_data();
-    failed += test_wrap_around_edges();
-    failed += test_invalid_move_wall();
-    failed += test_self_collision();
-    failed += test_reset_board();
-    failed += test_resize_board();
-    return failed;
 }
 
 int run_all_tests_with_report()

--- a/tests.hpp
+++ b/tests.hpp
@@ -1,13 +1,6 @@
 #ifndef TESTS_HPP
 #define TESTS_HPP
 
-int test_game_data();
-int test_wrap_around_edges();
-int test_invalid_move_wall();
-int test_self_collision();
-int test_reset_board();
-int test_resize_board();
-int run_all_tests();
 int run_all_tests_with_report();
 
 #endif


### PR DESCRIPTION
## Summary
- allow external code to call `update_game_map`
- use `update_game_map` in unit tests

## Testing
- `make`
- `./dnd_tools`


------
https://chatgpt.com/codex/tasks/task_e_688a28b2b36883318aff3c646f051d88