### PR TITLE
Add save system and achievement

### DIFF
--- a/game_data.cpp
+++ b/game_data.cpp
@@ -2,15 +2,33 @@
 #include "libft/Game/character.hpp"
 #include "libft/Game/map3d.hpp"
 #include "libft/RNG/dice_roll.hpp"
+#include "libft/JSon/json.hpp"
+#include <filesystem>
+#include <cstdlib>
+#include <string>
+#include <cstring>
+
+static std::filesystem::path get_save_dir()
+{
+    return std::filesystem::current_path() / "save_data";
+}
+
+static void ensure_save_dir_exists()
+{
+    std::filesystem::path dir = get_save_dir();
+    if (!std::filesystem::exists(dir))
+        std::filesystem::create_directories(dir);
+}
 
 game_data::game_data(int width, int height) :
         _error(0), _wrap_around_edges(0), _amount_players_dead(0),
+        _profile_name("default"), _achievement_snake50(false),
         _map(width, height, 3), _character()
 {
-	if (this->_map.get_error())
-		this->_error = this->_map.get_error();
-	else if (this->_character.get_error())
-		this->_error = this->_character.get_error();
+        if (this->_map.get_error())
+                this->_error = this->_map.get_error();
+        else if (this->_character.get_error())
+                this->_error = this->_character.get_error();
         int index = 0;
         while (index < 4)
         {
@@ -19,6 +37,7 @@ game_data::game_data(int width, int height) :
                 this->_snake_length[index] = 1;
                 index++;
         }
+        ensure_save_dir_exists();
         this->reset_board();
         return ;
 }
@@ -304,7 +323,11 @@ int     game_data::update_snake_position(int player_head)
 
     bool ate_food = (this->_map.get(target_x, target_y, 2) == FOOD);
     if (ate_food && this->_snake_length[player_number] < MAX_SNAKE_LENGTH)
+    {
         this->_snake_length[player_number]++;
+        if (this->_snake_length[player_number] >= 50)
+            this->_achievement_snake50 = true;
+    }
     this->_map.set(target_x, target_y, 2, offset + 1);
     if (ate_food)
         spawn_food();
@@ -369,4 +392,63 @@ void game_data::spawn_food()
             return;
         }
     }
+}
+
+void game_data::set_profile_name(const ft_string &name)
+{
+    this->_profile_name = name;
+}
+
+const ft_string &game_data::get_profile_name() const
+{
+    return this->_profile_name;
+}
+
+int game_data::save_game() const
+{
+    ensure_save_dir_exists();
+    std::filesystem::path file = get_save_dir() / (std::string(this->_profile_name.c_str()) + ".json");
+    json_group *group = json_create_json_group("game");
+    if (!group)
+        return (1);
+    json_add_item_to_group(group, json_create_item("snake_length", this->_snake_length[0]));
+    json_add_item_to_group(group, json_create_item("achievement_snake50", this->_achievement_snake50));
+    int ret = json_write_to_file(file.c_str(), group);
+    json_free_groups(group);
+    return (ret);
+}
+
+int game_data::load_game()
+{
+    ensure_save_dir_exists();
+    std::filesystem::path file = get_save_dir() / (std::string(this->_profile_name.c_str()) + ".json");
+    json_group *root = json_read_from_file(file.c_str());
+    if (!root)
+        return (1);
+    json_group *group = json_find_group(root, "game");
+    if (!group)
+    {
+        json_free_groups(root);
+        return (1);
+    }
+    json_item *len = json_find_item(group, "snake_length");
+    if (len)
+        this->_snake_length[0] = std::atoi(len->value);
+    json_item *ach = json_find_item(group, "achievement_snake50");
+    if (ach)
+        this->_achievement_snake50 = (std::strcmp(ach->value, "true") == 0 || std::strcmp(ach->value, "1") == 0);
+    json_free_groups(root);
+    return (0);
+}
+
+int game_data::get_snake_length(int player) const
+{
+    if (player >= 0 && player < 4)
+        return this->_snake_length[player];
+    return 0;
+}
+
+bool game_data::get_achievement_snake50() const
+{
+    return this->_achievement_snake50;
 }

--- a/game_data.hpp
+++ b/game_data.hpp
@@ -1,5 +1,6 @@
 #include "libft/Game/character.hpp"
 #include "libft/Game/map3d.hpp"
+#include "libft/CPP_class/string_class.hpp"
 
 #define GAME_TILE_EMPTY 0
 #define GAME_TILE_WALL 1
@@ -29,9 +30,9 @@ typedef struct s_coordinates
 
 class game_data
 {
-	public:
-    	game_data(int width, int height);
-    	void reset_board();
+        public:
+        game_data(int width, int height);
+        void reset_board();
     	void resize_board(int width, int height);
 
     	int  get_error() const;
@@ -47,22 +48,31 @@ class game_data
 
     	void spawn_food();
 
-    	t_coordinates get_head_coordinate(int head_to_find);
-    	int           is_valid_move(int player_head);
-    	int           update_snake_position(int player_head);
-    	int           update_game_map();
+        t_coordinates get_head_coordinate(int head_to_find);
+        int           is_valid_move(int player_head);
+        int           update_snake_position(int player_head);
+        int           update_game_map();
 
-	private:
-    	t_coordinates get_next_piece(t_coordinates current_coordinate, int piece_id);
-    	int           determine_player_number(int player_head);
+        void        set_profile_name(const ft_string &name);
+        const ft_string &get_profile_name() const;
+        int         save_game() const;
+        int         load_game();
+        int         get_snake_length(int player) const;
+        bool        get_achievement_snake50() const;
+
+        private:
+        t_coordinates get_next_piece(t_coordinates current_coordinate, int piece_id);
+        int           determine_player_number(int player_head);
 
     	mutable int _error;
     	int         _wrap_around_edges;
     	int         _amount_players_dead;
-    	int         _direction_moving[4];
-    	int         _direction_moving_ice[4];
-    	int         _snake_length[4];
+        int         _direction_moving[4];
+        int         _direction_moving_ice[4];
+        int         _snake_length[4];
+        ft_string   _profile_name;
+        bool        _achievement_snake50;
 
-    	ft_map3d     _map;
-    	ft_character _character;
+        ft_map3d     _map;
+        ft_character _character;
 };

--- a/tests.cpp
+++ b/tests.cpp
@@ -139,6 +139,40 @@ static int test_eat_food() {
     return 0;
 }
 
+static int test_save_load_and_achievement()
+{
+    game_data gd(100, 1);
+    if (gd.get_error())
+        return 1;
+    ft_string profile("profile1");
+    gd.set_profile_name(profile);
+    for (int i = 0; i < 49; ++i)
+    {
+        t_coordinates head = gd.get_head_coordinate(SNAKE_HEAD_PLAYER_1);
+        gd.set_map_value(head.x + 1, head.y, 2, FOOD);
+        gd.set_direction_moving(0, DIRECTION_RIGHT);
+        if (gd.update_game_map())
+            return 1;
+    }
+    if (gd.get_snake_length(0) != 50)
+        return 1;
+    if (!gd.get_achievement_snake50())
+        return 1;
+    if (gd.save_game())
+        return 1;
+    game_data gd2(100, 1);
+    if (gd2.get_error())
+        return 1;
+    gd2.set_profile_name(profile);
+    if (gd2.load_game())
+        return 1;
+    if (gd2.get_snake_length(0) != 50)
+        return 1;
+    if (!gd2.get_achievement_snake50())
+        return 1;
+    return 0;
+}
+
 int run_all_tests_with_report()
 {
     struct test_entry
@@ -155,6 +189,7 @@ int run_all_tests_with_report()
         {"test_reset_board", test_reset_board},
         {"test_resize_board", test_resize_board},
         {"test_eat_food", test_eat_food},
+        {"test_save_load_and_achievement", test_save_load_and_achievement},
     };
 
     int failed = 0;


### PR DESCRIPTION
## Summary
- Track a player profile name in `game_data` and expose getters, setters, and helpers to save/load game state as JSON
- Persist snake length and a new 50-length achievement in a `save_data` directory
- Add regression test covering achievement unlocking and save/load behavior

## Testing
- `./dnd_tools`

------
https://chatgpt.com/codex/tasks/task_e_688df1e8639483319ff31b658d64c0ea