### PR TITLE
Track empty cells for efficient food placement

### DIFF
--- a/game_data.hpp
+++ b/game_data.hpp
@@ -1,6 +1,7 @@
 #include "libft/Game/character.hpp"
 #include "libft/Game/map3d.hpp"
 #include "libft/CPP_class/string_class.hpp"
+#include <vector>
 
 #define GAME_TILE_EMPTY 0
 #define GAME_TILE_WALL 1
@@ -58,11 +59,14 @@ class game_data
         int         save_game() const;
         int         load_game();
         int         get_snake_length(int player) const;
-        bool        get_achievement_snake50() const;
+    bool        get_achievement_snake50() const;
 
     private:
         t_coordinates get_next_piece(t_coordinates current_coordinate, int piece_id);
         int           determine_player_number(int player_head);
+        void          add_empty_cell(int x, int y);
+        void          remove_empty_cell(int x, int y);
+        void          initialize_empty_cells();
 
     	mutable int _error;
     	int         _wrap_around_edges;
@@ -75,4 +79,6 @@ class game_data
 
         ft_map3d     _map;
         ft_character _character;
+        std::vector<t_coordinates> _empty_cells;
+        std::vector<int>           _empty_cell_indices;
 };


### PR DESCRIPTION
## Summary
- Maintain a vector of empty cells and indices so food placement selects from available spaces without rerolling.
- Update map setters, reset routine, and snake movement to keep the empty-cell list in sync.
- Spawn food using the tracked empty cells for constant-time placement.

## Testing
- `make`
- `./dnd_tools`


------
https://chatgpt.com/codex/tasks/task_e_688e23a4f9a4833199aa0d1a5fe1c063