### PR TITLE
Add tick-based snake movement via update counters

### DIFF
--- a/game_data.hpp
+++ b/game_data.hpp
@@ -74,6 +74,7 @@ class game_data
         int         _direction_moving[4];
         int         _direction_moving_ice[4];
         int         _snake_length[4];
+        int         _update_counter[4];
         ft_string   _profile_name;
         bool        _achievement_snake50;
 

--- a/game_data_board.cpp
+++ b/game_data_board.cpp
@@ -122,6 +122,7 @@ void game_data::reset_board()
         this->_direction_moving[i] = 0;
         this->_direction_moving_ice[i] = 0;
         this->_snake_length[i] = 1;
+        this->_update_counter[i] = 0;
         ++i;
     }
     this->_amount_players_dead = 0;

--- a/game_data_io.cpp
+++ b/game_data_io.cpp
@@ -35,6 +35,7 @@ game_data::game_data(int width, int height) :
                 this->_direction_moving_ice[index] = 0;
                 this->_direction_moving[index] = 0;
                 this->_snake_length[index] = 1;
+                this->_update_counter[index] = 0;
                 index++;
         }
         ensure_save_dir_exists();

--- a/game_data_movement.cpp
+++ b/game_data_movement.cpp
@@ -166,7 +166,28 @@ t_coordinates game_data::get_next_piece(t_coordinates current_coordinate, int pi
 
 int game_data::update_game_map()
 {
-    return (update_snake_position(SNAKE_HEAD_PLAYER_1));
+    int ret = 0;
+    int heads[4] = {
+        SNAKE_HEAD_PLAYER_1,
+        SNAKE_HEAD_PLAYER_2,
+        SNAKE_HEAD_PLAYER_3,
+        SNAKE_HEAD_PLAYER_4};
+    int i = 0;
+    while (i < 4)
+    {
+        if (this->_snake_length[i] > 0)
+        {
+            this->_update_counter[i]++;
+            if (this->_update_counter[i] >= 60)
+            {
+                this->_update_counter[i] = 0;
+                if (update_snake_position(heads[i]))
+                    ret = 1;
+            }
+        }
+        ++i;
+    }
+    return (ret);
 }
 
 int game_data::update_snake_position(int player_head)

--- a/tests.cpp
+++ b/tests.cpp
@@ -21,6 +21,20 @@ static void print_layer(const game_data &gd)
 	return ;
 }
 
+static int perform_updates(game_data &gd, int expected)
+{
+    int i = 0;
+    while (i < 59)
+    {
+        if (gd.update_game_map())
+            return (1);
+        ++i;
+    }
+    if (gd.update_game_map() != expected)
+        return (1);
+    return (0);
+}
+
 static int test_game_data()
 {
     game_data gd(3, 3);
@@ -31,7 +45,7 @@ static int test_game_data()
     }
     gd.set_map_value(0, 0, 2, SNAKE_HEAD_PLAYER_1);
     gd.set_direction_moving(0, DIRECTION_RIGHT);
-    if (gd.update_game_map())
+    if (perform_updates(gd, 0))
     {
         std::cerr << "Update failed" << std::endl;
         return (1);
@@ -55,7 +69,7 @@ static int test_wrap_around_edges()
     gd.set_wrap_around_edges(1);
     gd.set_map_value(1, 0, 2, SNAKE_HEAD_PLAYER_1);
     gd.set_direction_moving(0, DIRECTION_RIGHT);
-    if (gd.update_game_map())
+    if (perform_updates(gd, 0))
         return (1);
     t_coordinates head = gd.get_head_coordinate(SNAKE_HEAD_PLAYER_1);
     if (head.x != 0 || head.y != 0)
@@ -73,7 +87,7 @@ static int test_invalid_move_wall()
     gd.set_direction_moving(0, DIRECTION_RIGHT);
     if (gd.is_valid_move(SNAKE_HEAD_PLAYER_1) == 0)
         return (1);
-    if (gd.update_game_map() == 0)
+    if (perform_updates(gd, 1) == 0)
         return (1);
     return (0);
 }
@@ -88,7 +102,7 @@ static int test_self_collision()
     gd.set_direction_moving(0, DIRECTION_LEFT);
     if (gd.is_valid_move(SNAKE_HEAD_PLAYER_1) == 0)
         return (1);
-    if (gd.update_game_map() == 0)
+    if (perform_updates(gd, 1) == 0)
         return (1);
     return (0);
 }
@@ -124,7 +138,7 @@ static int test_eat_food() {
     gd.set_map_value(0, 0, 2, SNAKE_HEAD_PLAYER_1);
     gd.set_map_value(1, 0, 2, FOOD);
     gd.set_direction_moving(0, DIRECTION_RIGHT);
-    if (gd.update_game_map())
+    if (perform_updates(gd, 0))
         return (1);
     if (gd.get_map_value(0, 0, 2) == 0)
         return (1);
@@ -153,7 +167,7 @@ static int test_save_load_and_achievement()
         t_coordinates head = gd.get_head_coordinate(SNAKE_HEAD_PLAYER_1);
         gd.set_map_value(head.x + 1, head.y, 2, FOOD);
         gd.set_direction_moving(0, DIRECTION_RIGHT);
-        if (gd.update_game_map())
+        if (perform_updates(gd, 0))
             return (1);
     }
     if (gd.get_snake_length(0) != 50)


### PR DESCRIPTION
## Summary
- Track per-snake update counters to move snakes only every 60 ticks
- Reset counters on construction and board reset
- Adjust tests to account for the tick-based update

## Testing
- `make` *(fails: No targets specified and no makefile found in libft)*

------
https://chatgpt.com/codex/tasks/task_e_688e494341188331b70ab559524e20b4