### PR TITLE
chore: qualify member calls with this

### DIFF
--- a/game_data_board.cpp
+++ b/game_data_board.cpp
@@ -8,18 +8,18 @@ void game_data::set_map_value(int x, int y, int layer, int value)
     if (layer == 2)
     {
         if (prev_val == 0 && value != 0)
-            remove_empty_cell(x, y);
+            this->remove_empty_cell(x, y);
         else if (prev_val != 0 && value == 0 &&
                  this->_map.get(x, y, 0) != GAME_TILE_WALL)
-            add_empty_cell(x, y);
+            this->add_empty_cell(x, y);
     }
     else if (layer == 0)
     {
         if (value == GAME_TILE_WALL)
-            remove_empty_cell(x, y);
+            this->remove_empty_cell(x, y);
         else if (prev_val == GAME_TILE_WALL &&
                  this->_map.get(x, y, 2) == 0)
-            add_empty_cell(x, y);
+            this->add_empty_cell(x, y);
     }
     return ;
 }
@@ -126,12 +126,12 @@ void game_data::reset_board()
         ++i;
     }
     this->_amount_players_dead = 0;
-    initialize_empty_cells();
+    this->initialize_empty_cells();
     int mid_x = static_cast<int>(this->_map.get_width() / 2);
     int mid_y = static_cast<int>(this->_map.get_height() / 2);
     this->_map.set(mid_x, mid_y, 2, SNAKE_HEAD_PLAYER_1);
-    remove_empty_cell(mid_x, mid_y);
-    spawn_food();
+    this->remove_empty_cell(mid_x, mid_y);
+    this->spawn_food();
     return ;
 }
 
@@ -154,7 +154,7 @@ void game_data::spawn_food()
     int idx = ft_dice_roll(1, static_cast<int>(this->_empty_cells.size())) - 1;
     t_coordinates coord = this->_empty_cells[idx];
     this->_map.set(coord.x, coord.y, 2, FOOD);
-    remove_empty_cell(coord.x, coord.y);
+    this->remove_empty_cell(coord.x, coord.y);
     return ;
 }
 

--- a/game_data_movement.cpp
+++ b/game_data_movement.cpp
@@ -26,7 +26,7 @@ int game_data::determine_player_number(int player_head)
 int game_data::is_valid_move(int player_head)
 {
     t_coordinates head = this->get_head_coordinate(player_head);
-    int player_number = determine_player_number(player_head);
+    int player_number = this->determine_player_number(player_head);
 
     int direction_moving = this->_direction_moving[player_number];
     if (this->_map.get(head.x, head.y, 0) == GAME_TILE_ICE)
@@ -181,7 +181,7 @@ int game_data::update_game_map()
             if (this->_update_counter[i] >= 60)
             {
                 this->_update_counter[i] = 0;
-                if (update_snake_position(heads[i]))
+                if (this->update_snake_position(heads[i]))
                     ret = 1;
             }
         }
@@ -192,10 +192,10 @@ int game_data::update_game_map()
 
 int game_data::update_snake_position(int player_head)
 {
-    t_coordinates current_coords = get_head_coordinate(player_head);
-    int player_number = determine_player_number(player_head);
+    t_coordinates current_coords = this->get_head_coordinate(player_head);
+    int player_number = this->determine_player_number(player_head);
 
-    if (is_valid_move(player_head))
+    if (this->is_valid_move(player_head))
         return (1);
     int direction_moving = this->_direction_moving[player_number];
     if (this->_map.get(current_coords.x, current_coords.y, 0) == GAME_TILE_ICE)
@@ -250,7 +250,7 @@ int game_data::update_snake_position(int player_head)
             else if (val >= offset + limit)
             {
                 this->_map.set(x, y, 2, 0);
-                add_empty_cell(x, y);
+                this->add_empty_cell(x, y);
             }
             x++;
         }
@@ -263,10 +263,10 @@ int game_data::update_snake_position(int player_head)
         if (this->_snake_length[player_number] >= 50)
             this->_achievement_snake50 = true;
     }
-    remove_empty_cell(target_x, target_y);
+    this->remove_empty_cell(target_x, target_y);
     this->_map.set(target_x, target_y, 2, offset + 1);
     if (ate_food)
-        spawn_food();
+        this->spawn_food();
     return (0);
 }
 


### PR DESCRIPTION
## Summary
- explicitly use `this->` when invoking `game_data` member functions

## Testing
- `make`
- `./dnd_tools` *(fails: test_save_load_and_achievement)*

------
https://chatgpt.com/codex/tasks/task_e_688e78ec501883318bf40ae2272522e6