### PR TITLE
Add achievements page to menu system

### DIFF
--- a/MenuSystem.cpp
+++ b/MenuSystem.cpp
@@ -1,4 +1,5 @@
 #include "MenuSystem.hpp"
+#include "game_data.hpp"
 #include <algorithm>
 
 MenuSystem::MenuSystem() : _currentState(MenuState::MAIN_MENU), _currentSelection(0), _gameOverScore(0) {
@@ -57,7 +58,10 @@ void MenuSystem::selectCurrentItem() {
                 case 3: // Instructions
                     setState(MenuState::INSTRUCTIONS_PAGE);
                     break;
-                case 4: // Exit
+                case 4: // Achievements
+                    setState(MenuState::ACHIEVEMENTS_PAGE);
+                    break;
+                case 5: // Exit
                     setState(MenuState::EXIT_REQUESTED);
                     break;
             }
@@ -79,6 +83,7 @@ void MenuSystem::selectCurrentItem() {
             
         case MenuState::CREDITS_PAGE:
         case MenuState::INSTRUCTIONS_PAGE:
+        case MenuState::ACHIEVEMENTS_PAGE:
             goBack();
             break;
 
@@ -106,6 +111,7 @@ void MenuSystem::goBack() {
         case MenuState::SETTINGS_MENU:
         case MenuState::CREDITS_PAGE:
         case MenuState::INSTRUCTIONS_PAGE:
+        case MenuState::ACHIEVEMENTS_PAGE:
             setState(MenuState::MAIN_MENU);
             break;
         case MenuState::IN_GAME:
@@ -142,6 +148,8 @@ std::string MenuSystem::getCurrentTitle() const {
             return "CREDITS";
         case MenuState::INSTRUCTIONS_PAGE:
             return "INSTRUCTIONS";
+        case MenuState::ACHIEVEMENTS_PAGE:
+            return "ACHIEVEMENTS";
         case MenuState::IN_GAME:
             return "NIBBLER";
         case MenuState::GAME_OVER:
@@ -158,6 +166,7 @@ void MenuSystem::initializeMenus() {
         MenuItem("Settings"),
         MenuItem("Credits"),
         MenuItem("Instructions"),
+        MenuItem("Achievements"),
         MenuItem("Exit")
     };
 
@@ -290,6 +299,18 @@ std::vector<std::string> MenuSystem::getInstructionsContent() const {
         "",
         "Press ESC or ENTER to return to main menu"
     };
+}
+
+std::vector<std::string> MenuSystem::getAchievementsContent(const game_data& game) const {
+    std::vector<std::string> content = {
+        "PLAYER ACHIEVEMENTS",
+        ""
+    };
+
+    content.push_back(std::string("• Reach length 50: ") + (game.get_achievement_snake50() ? "Unlocked" : "Locked"));
+    content.push_back("");
+    content.push_back("Press ESC or ENTER to return to main menu");
+    return content;
 }
 
 void MenuSystem::setGameOverScore(int score) {

--- a/MenuSystem.hpp
+++ b/MenuSystem.hpp
@@ -4,11 +4,14 @@
 #include <string>
 #include <vector>
 
+class game_data;
+
 enum class MenuState {
     MAIN_MENU,
     SETTINGS_MENU,
     CREDITS_PAGE,
     INSTRUCTIONS_PAGE,
+    ACHIEVEMENTS_PAGE,
     IN_GAME,
     GAME_OVER,
     EXIT_REQUESTED
@@ -66,6 +69,7 @@ public:
     // Content getters for pages
     std::vector<std::string> getCreditsContent() const;
     std::vector<std::string> getInstructionsContent() const;
+    std::vector<std::string> getAchievementsContent(const game_data& game) const;
     std::vector<std::string> getSettingsContent() const;
     
     // Settings modification

--- a/graphics_libs/NCursesGraphics.cpp
+++ b/graphics_libs/NCursesGraphics.cpp
@@ -96,7 +96,7 @@ void NCursesGraphics::render(const game_data& game) {
 
     // Check if we should render menu instead of game
     if (_menuSystem && _menuSystem->getCurrentState() != MenuState::IN_GAME) {
-        renderMenu();
+        renderMenu(game);
         refresh();
         return;
     }
@@ -414,7 +414,7 @@ void NCursesGraphics::forceInputReadiness() {
 }
 
 // Menu rendering methods
-void NCursesGraphics::renderMenu() {
+void NCursesGraphics::renderMenu(const game_data& game) {
     if (!_menuSystem) return;
 
     switch (_menuSystem->getCurrentState()) {
@@ -429,6 +429,9 @@ void NCursesGraphics::renderMenu() {
             break;
         case MenuState::INSTRUCTIONS_PAGE:
             renderInstructionsPage();
+            break;
+        case MenuState::ACHIEVEMENTS_PAGE:
+            renderAchievementsPage(game);
             break;
         case MenuState::GAME_OVER:
             renderGameOverScreen();
@@ -583,6 +586,37 @@ void NCursesGraphics::renderInstructionsPage() {
             line.find("MULTIPLAYER") != std::string::npos || line.find("GRAPHICS") != std::string::npos) {
             colorPair = COLOR_SNAKE_HEAD;
         } else if (line.find("•") != std::string::npos || line.find("Key") != std::string::npos) {
+            colorPair = COLOR_FOOD;
+        }
+
+        drawCenteredText(startY + static_cast<int>(i), line, colorPair);
+    }
+
+    // Draw footer
+    attron(COLOR_PAIR(COLOR_BORDER));
+    drawCenteredText(termHeight - 2, "Press ESC or ENTER to return to main menu");
+    attroff(COLOR_PAIR(COLOR_BORDER));
+}
+
+void NCursesGraphics::renderAchievementsPage(const game_data& game) {
+    int termHeight, termWidth;
+    getmaxyx(stdscr, termHeight, termWidth);
+
+    // Draw title
+    attron(COLOR_PAIR(COLOR_SNAKE_HEAD) | A_BOLD);
+    drawCenteredText(2, _menuSystem->getCurrentTitle());
+    attroff(COLOR_PAIR(COLOR_SNAKE_HEAD) | A_BOLD);
+
+    // Draw content
+    auto content = _menuSystem->getAchievementsContent(game);
+    int startY = 4;
+
+    for (size_t i = 0; i < content.size() && startY + static_cast<int>(i) < termHeight - 2; ++i) {
+        const std::string& line = content[i];
+        if (line.empty()) continue;
+
+        int colorPair = COLOR_INFO;
+        if (line.find("Unlocked") != std::string::npos) {
             colorPair = COLOR_FOOD;
         }
 

--- a/graphics_libs/NCursesGraphics.hpp
+++ b/graphics_libs/NCursesGraphics.hpp
@@ -67,11 +67,12 @@ private:
     void clearError();
 
     // Menu rendering methods
-    void renderMenu();
+    void renderMenu(const game_data& game);
     void renderMainMenu();
     void renderSettingsMenu();
     void renderCreditsPage();
     void renderInstructionsPage();
+    void renderAchievementsPage(const game_data& game);
     void renderGameOverScreen();
     void drawCenteredText(int y, const std::string& text, int colorPair = 0);
     void drawMenuItems(const std::vector<MenuItem>& items, int selection, int startY);

--- a/graphics_libs/SDL2Graphics.cpp
+++ b/graphics_libs/SDL2Graphics.cpp
@@ -136,7 +136,7 @@ void SDL2Graphics::render(const game_data& game) {
 
     // Check if we should render menu instead of game
     if (_menuSystem && _menuSystem->getCurrentState() != MenuState::IN_GAME) {
-        renderMenu();
+        renderMenu(game);
         SDL_RenderPresent(_renderer);
         return;
     }
@@ -347,7 +347,7 @@ void SDL2Graphics::setSwitchMessage(const std::string& message, int timer) {
 }
 
 // Menu rendering methods
-void SDL2Graphics::renderMenu() {
+void SDL2Graphics::renderMenu(const game_data& game) {
     if (!_menuSystem) return;
 
     switch (_menuSystem->getCurrentState()) {
@@ -362,6 +362,9 @@ void SDL2Graphics::renderMenu() {
             break;
         case MenuState::INSTRUCTIONS_PAGE:
             renderInstructionsMenu();
+            break;
+        case MenuState::ACHIEVEMENTS_PAGE:
+            renderAchievementsMenu(game);
             break;
         case MenuState::GAME_OVER:
             renderGameOverMenu();
@@ -427,6 +430,25 @@ void SDL2Graphics::renderInstructionsMenu() {
 
     // Draw content
     auto content = _menuSystem->getInstructionsContent();
+    int startY = 100;
+
+    for (size_t i = 0; i < content.size() && startY + static_cast<int>(i) * 25 < WINDOW_HEIGHT - 60; ++i) {
+        const std::string& line = content[i];
+        if (line.empty()) continue;
+
+        drawCenteredText(line, startY + static_cast<int>(i) * 25, COLOR_TEXT);
+    }
+
+    // Draw footer
+    drawCenteredText("ESC to go back", WINDOW_HEIGHT - 40, COLOR_TEXT);
+}
+
+void SDL2Graphics::renderAchievementsMenu(const game_data& game) {
+    // Draw title
+    drawCenteredText(_menuSystem->getCurrentTitle(), 40, COLOR_SNAKE_HEAD);
+
+    // Draw content
+    auto content = _menuSystem->getAchievementsContent(game);
     int startY = 100;
 
     for (size_t i = 0; i < content.size() && startY + static_cast<int>(i) * 25 < WINDOW_HEIGHT - 60; ++i) {

--- a/graphics_libs/SDL2Graphics.hpp
+++ b/graphics_libs/SDL2Graphics.hpp
@@ -71,11 +71,12 @@ private:
     void calculateGameArea(const game_data& game, int& offsetX, int& offsetY, int& cellSize);
 
     // Menu rendering methods
-    void renderMenu();
+    void renderMenu(const game_data& game);
     void renderMainMenu();
     void renderSettingsMenu();
     void renderCreditsMenu();
     void renderInstructionsMenu();
+    void renderAchievementsMenu(const game_data& game);
     void renderGameOverMenu();
     void drawCenteredText(const std::string& text, int y, const Color& color = COLOR_TEXT);
     void drawMenuItems(const std::vector<MenuItem>& items, int selectedIndex, int startY);


### PR DESCRIPTION
## Summary
- Add ACHIEVEMENTS_PAGE to MenuState with new content provider
- Insert Achievements option in main menu and hook up navigation/title/back logic
- Render achievements page in SDL2 and NCurses graphics libraries

## Testing
- `make` (failed: No targets specified and no makefile found for libft/Full_Libft.a)

------
https://chatgpt.com/codex/tasks/task_e_689cc4d18148833185495a67f08c10a0