### PR TITLE
Make snake update rate configurable

### DIFF
--- a/game_data.hpp
+++ b/game_data.hpp
@@ -46,9 +46,12 @@ class game_data
 
     	int  get_error() const;
     	void set_wrap_around_edges(int value);
-    	int  get_wrap_around_edges() const;
-    	void set_direction_moving(int player, int direction);
-    	int  get_direction_moving(int player) const;
+        int  get_wrap_around_edges() const;
+        void set_direction_moving(int player, int direction);
+        int  get_direction_moving(int player) const;
+
+        void set_moves_per_second(double moves);
+        double get_moves_per_second() const;
 
     	void   set_map_value(int x, int y, int layer, int value);
     	int    get_map_value(int x, int y, int layer) const;
@@ -88,6 +91,7 @@ class game_data
         int         _direction_moving_ice[4];
         int         _snake_length[4];
         double      _update_timer[4];
+        double      _moves_per_second;
         ft_string   _profile_name;
         ft_map3d     				_map;
         ft_character 				_character;

--- a/game_data_core.cpp
+++ b/game_data_core.cpp
@@ -16,6 +16,17 @@ int game_data::get_wrap_around_edges() const
     return (this->_wrap_around_edges);
 }
 
+void game_data::set_moves_per_second(double moves)
+{
+    this->_moves_per_second = moves;
+    return ;
+}
+
+double game_data::get_moves_per_second() const
+{
+    return (this->_moves_per_second);
+}
+
 
 void game_data::set_direction_moving(int player, int direction)
 {

--- a/game_data_io.cpp
+++ b/game_data_io.cpp
@@ -23,6 +23,7 @@ static void ensure_save_dir_exists()
 
 game_data::game_data(int width, int height) :
         _error(0), _wrap_around_edges(0), _amount_players_dead(0),
+        _moves_per_second(1.0),
         _profile_name("default"),
         _map(width, height, 3), _character()
 {

--- a/game_data_movement.cpp
+++ b/game_data_movement.cpp
@@ -315,7 +315,7 @@ int game_data::update_game_map(double deltaTime)
         SNAKE_HEAD_PLAYER_2,
         SNAKE_HEAD_PLAYER_3,
         SNAKE_HEAD_PLAYER_4};
-    const double moveInterval = 1.0 / 12.0; // Move 12 times per second
+    const double moveInterval = 1.0 / this->_moves_per_second; // Moves per second is configurable
     int i = 0;
     while (i < 4)
     {


### PR DESCRIPTION
## Summary
- add moves-per-second field with getter and setter on `game_data`
- initialize move speed to 1 update per second
- use configurable move interval in game map update

## Testing
- `make` *(fails: make[1]: *** No targets specified and no makefile found.  Stop.)*


------
https://chatgpt.com/codex/tasks/task_e_68a8c532a78c8331a935f1e3fb6987ba