### PR TITLE
Add optional fire and frosty foods plus fire tile

### DIFF
--- a/GameEngine.cpp
+++ b/GameEngine.cpp
@@ -440,6 +440,7 @@ void GameEngine::applyMenuSettings() {
 
     // Apply wrap around setting
     _gameData.set_wrap_around_edges(settings.wrapAroundEdges ? 1 : 0);
+    _gameData.set_additional_food_items(settings.additionalFoodItems ? 1 : 0);
 
     // Apply frame rate to current graphics library
     IGraphicsLibrary* currentLib = _libraryManager.getCurrentLibrary();

--- a/MenuSystem.cpp
+++ b/MenuSystem.cpp
@@ -73,10 +73,11 @@ void MenuSystem::selectCurrentItem() {
             else if (_currentSelection == 1) adjustGameSpeed(10);
             else if (_currentSelection == 2) toggleWrapAround();
             // Board size (index 3) is non-selectable - skip
-            else if (_currentSelection == 4) toggleAlternativeColors();
-            else if (_currentSelection == 5) toggleGrid();
-            else if (_currentSelection == 6) toggleFPS();
-            else if (_currentSelection == 8) goBack(); // Back to Main Menu (adjusted index)
+            else if (_currentSelection == 4) toggleAdditionalFoodItems();
+            else if (_currentSelection == 5) toggleAlternativeColors();
+            else if (_currentSelection == 6) toggleGrid();
+            else if (_currentSelection == 7) toggleFPS();
+            else if (_currentSelection == 9) goBack(); // Back to Main Menu (adjusted index)
 
             updateSettingsMenu();
             break;
@@ -190,10 +191,11 @@ void MenuSystem::updateSettingsMenu() {
     _settingsMenuItems.emplace_back("Game Speed: " + std::to_string(_settings.gameSpeed) + " FPS");
     _settingsMenuItems.emplace_back("Wrap Around Edges: " + std::string(_settings.wrapAroundEdges ? "ON" : "OFF"));
     _settingsMenuItems.emplace_back("Board Size: " + std::to_string(_settings.boardWidth) + "x" + std::to_string(_settings.boardHeight) + " (from command line)", false);
+    _settingsMenuItems.emplace_back("Additional Foods: " + std::string(_settings.additionalFoodItems ? "ON" : "OFF"));
     _settingsMenuItems.emplace_back("Alternative Colors: " + std::string(_settings.useAlternativeColors ? "ON" : "OFF"));
     _settingsMenuItems.emplace_back("Show Grid: " + std::string(_settings.showGrid ? "ON" : "OFF"));
     _settingsMenuItems.emplace_back("Show FPS: " + std::string(_settings.showFPS ? "ON" : "OFF"));
-    
+
     _settingsMenuItems.emplace_back("", false); // Spacer
     _settingsMenuItems.emplace_back("Back to Main Menu");
 }
@@ -210,6 +212,10 @@ void MenuSystem::adjustGameSpeed(int delta) {
 
 void MenuSystem::toggleWrapAround() {
     _settings.wrapAroundEdges = !_settings.wrapAroundEdges;
+}
+
+void MenuSystem::toggleAdditionalFoodItems() {
+    _settings.additionalFoodItems = !_settings.additionalFoodItems;
 }
 
 void MenuSystem::adjustBoardSize(int widthDelta, int heightDelta) {

--- a/MenuSystem.hpp
+++ b/MenuSystem.hpp
@@ -28,6 +28,7 @@ struct GameSettings {
     bool wrapAroundEdges = false;
     int boardWidth = 15;
     int boardHeight = 10;
+    bool additionalFoodItems = false;
     
     // Graphics settings (can be extended per library)
     bool useAlternativeColors = false;
@@ -76,6 +77,7 @@ public:
     void toggleGameMode();
     void adjustGameSpeed(int delta);
     void toggleWrapAround();
+    void toggleAdditionalFoodItems();
     void adjustBoardSize(int widthDelta, int heightDelta);
     void toggleAlternativeColors();
     void toggleGrid();

--- a/game_data.hpp
+++ b/game_data.hpp
@@ -9,6 +9,7 @@
 #define GAME_TILE_EMPTY 0
 #define GAME_TILE_WALL 1
 #define GAME_TILE_ICE 2
+#define GAME_TILE_FIRE 3
 
 #define SNAKE_HEAD_PLAYER_1 1000001
 #define SNAKE_HEAD_PLAYER_2 2000001
@@ -26,6 +27,8 @@
 
 static const int MAX_SNAKE_LENGTH = 40000;
 #define FOOD 1
+#define FIRE_FOOD 2
+#define FROSTY_FOOD 3
 
 #define ACH_APPLES_EATEN 0
 #define ACH_SNAKE_50 1
@@ -42,23 +45,25 @@ class game_data
     public:
         game_data(int width, int height);
         void reset_board();
-    	void resize_board(int width, int height);
+        void resize_board(int width, int height);
 
-    	int  get_error() const;
-    	void set_wrap_around_edges(int value);
+        int  get_error() const;
+        void set_wrap_around_edges(int value);
         int  get_wrap_around_edges() const;
         void set_direction_moving(int player, int direction);
         int  get_direction_moving(int player) const;
 
         void set_moves_per_second(double moves);
         double get_moves_per_second() const;
+        void set_additional_food_items(int value);
+        int  get_additional_food_items() const;
 
-    	void   set_map_value(int x, int y, int layer, int value);
-    	int    get_map_value(int x, int y, int layer) const;
-    	size_t get_width() const;
-    	size_t get_height() const;
+        void   set_map_value(int x, int y, int layer, int value);
+        int    get_map_value(int x, int y, int layer) const;
+        size_t get_width() const;
+        size_t get_height() const;
 
-    	t_coordinates get_head_coordinate(int head_to_find);
+        t_coordinates get_head_coordinate(int head_to_find);
 
         int         update_game_map(double deltaTime);
 
@@ -82,21 +87,25 @@ class game_data
 
         int         is_valid_move(int player_head);
         int         update_snake_position(int player_head);
-		void 		spawn_food();
+        void        spawn_food();
+        void        spawn_fire_tile();
 
-    	mutable int _error;
-    	int         _wrap_around_edges;
-    	int         _amount_players_dead;
+        mutable int _error;
+        int         _wrap_around_edges;
+        int         _amount_players_dead;
         int         _direction_moving[4];
         int         _direction_moving_ice[4];
+        int         _speed_boost_steps[4];
+        int         _frosty_steps[4];
         int         _snake_length[4];
         double      _update_timer[4];
         double      _moves_per_second;
+        int         _additional_food_items;
         ft_string   _profile_name;
-        ft_map3d     				_map;
-        ft_character 				_character;
-        std::vector<t_coordinates> 	_empty_cells;
-        std::vector<int>           	_empty_cell_indices;
+        ft_map3d                                _map;
+        ft_character                            _character;
+        std::vector<t_coordinates>      _empty_cells;
+        std::vector<int>                _empty_cell_indices;
 };
 
 #endif // GAME_DATA_HPP

--- a/game_data_board.cpp
+++ b/game_data_board.cpp
@@ -121,6 +121,8 @@ void game_data::reset_board()
     {
         this->_direction_moving[i] = DIRECTION_NONE;
         this->_direction_moving_ice[i] = 0;
+        this->_speed_boost_steps[i] = 0;
+        this->_frosty_steps[i] = 0;
         // Only initialize Player 1 snake, others are inactive (length 0)
         this->_snake_length[i] = (i == 0) ? 4 : 0;
         this->_update_timer[i] = 0.0;
@@ -146,6 +148,8 @@ void game_data::reset_board()
     }
 
     this->spawn_food();
+    if (this->_additional_food_items)
+        this->spawn_fire_tile();
     return ;
 }
 
@@ -167,7 +171,27 @@ void game_data::spawn_food()
         return ;
     int idx = ft_dice_roll(1, static_cast<int>(this->_empty_cells.size())) - 1;
     t_coordinates coord = this->_empty_cells[idx];
-    this->_map.set(coord.x, coord.y, 2, FOOD);
+    int item = FOOD;
+    if (this->_additional_food_items)
+    {
+        int roll = ft_dice_roll(1, 3);
+        if (roll == 2)
+            item = FIRE_FOOD;
+        else if (roll == 3)
+            item = FROSTY_FOOD;
+    }
+    this->_map.set(coord.x, coord.y, 2, item);
+    this->remove_empty_cell(coord.x, coord.y);
+    return ;
+}
+
+void game_data::spawn_fire_tile()
+{
+    if (this->_empty_cells.empty())
+        return ;
+    int idx = ft_dice_roll(1, static_cast<int>(this->_empty_cells.size())) - 1;
+    t_coordinates coord = this->_empty_cells[idx];
+    this->_map.set(coord.x, coord.y, 0, GAME_TILE_FIRE);
     this->remove_empty_cell(coord.x, coord.y);
     return ;
 }

--- a/game_data_core.cpp
+++ b/game_data_core.cpp
@@ -27,6 +27,16 @@ double game_data::get_moves_per_second() const
     return (this->_moves_per_second);
 }
 
+void game_data::set_additional_food_items(int value)
+{
+    this->_additional_food_items = value;
+}
+
+int game_data::get_additional_food_items() const
+{
+    return (this->_additional_food_items);
+}
+
 
 void game_data::set_direction_moving(int player, int direction)
 {

--- a/game_data_io.cpp
+++ b/game_data_io.cpp
@@ -23,7 +23,7 @@ static void ensure_save_dir_exists()
 
 game_data::game_data(int width, int height) :
         _error(0), _wrap_around_edges(0), _amount_players_dead(0),
-        _moves_per_second(1.0),
+        _moves_per_second(1.0), _additional_food_items(0),
         _profile_name("default"),
         _map(width, height, 3), _character()
 {
@@ -36,6 +36,8 @@ game_data::game_data(int width, int height) :
         {
                 this->_direction_moving_ice[index] = 0;
                 this->_direction_moving[index] = DIRECTION_NONE;
+                this->_speed_boost_steps[index] = 0;
+                this->_frosty_steps[index] = 0;
                 // Only initialize Player 1 snake, others are inactive (length 0)
                 this->_snake_length[index] = (index == 0) ? 4 : 0;
                 this->_update_timer[index] = 0.0;

--- a/game_data_movement.cpp
+++ b/game_data_movement.cpp
@@ -30,7 +30,8 @@ int game_data::is_valid_move(int player_head)
     int player_number = this->determine_player_number(player_head);
 
     int direction_moving = this->_direction_moving[player_number];
-    if (this->_map.get(head.x, head.y, 0) == GAME_TILE_ICE)
+    if (this->_frosty_steps[player_number] > 0 ||
+        this->_map.get(head.x, head.y, 0) == GAME_TILE_ICE)
         direction_moving = this->_direction_moving_ice[player_number];
 
     // If no direction is set, the move is valid but the snake won't move
@@ -93,7 +94,7 @@ int game_data::is_valid_move(int player_head)
     }
 
     int target_val = this->_map.get(target_x, target_y, 2);
-    if (target_val != 0 && target_val != FOOD)
+    if (target_val != 0 && target_val != FOOD && target_val != FIRE_FOOD && target_val != FROSTY_FOOD)
         return (1);
     if (this->_map.get(target_x, target_y, 0) == GAME_TILE_WALL)
         return (1);
@@ -189,7 +190,9 @@ int game_data::update_snake_position(int player_head)
     if (this->is_valid_move(player_head) != 0)
         return (1);
     int direction_moving = this->_direction_moving[player_number];
-    if (this->_map.get(current_coords.x, current_coords.y, 0) == GAME_TILE_ICE)
+    bool frosty_active = (this->_frosty_steps[player_number] > 0);
+    if (frosty_active ||
+        this->_map.get(current_coords.x, current_coords.y, 0) == GAME_TILE_ICE)
         direction_moving = this->_direction_moving_ice[player_number];
     int width  = static_cast<int>(this->_map.get_width());
     int height = static_cast<int>(this->_map.get_height());
@@ -247,12 +250,21 @@ int game_data::update_snake_position(int player_head)
     bool on_ice_now = (this->_map.get(current_coords.x, current_coords.y, 0) ==
                 GAME_TILE_ICE);
     bool on_ice_next = (this->_map.get(target_x, target_y, 0) == GAME_TILE_ICE);
+    bool on_fire_next = (this->_map.get(target_x, target_y, 0) == GAME_TILE_FIRE);
     if (!on_ice_now && on_ice_next)
         this->_direction_moving_ice[player_number] = direction_moving;
-    else if (on_ice_now && !on_ice_next)
+    else if (on_ice_now && !on_ice_next && this->_frosty_steps[player_number] == 0)
         this->_direction_moving_ice[player_number] = 0;
+    if (frosty_active)
+    {
+        this->_direction_moving_ice[player_number] = direction_moving;
+        this->_frosty_steps[player_number]--;
+        if (this->_frosty_steps[player_number] == 0 && !on_ice_next)
+            this->_direction_moving_ice[player_number] = 0;
+    }
     int offset = (player_head / 1000000) * 1000000;
-    bool ate_food = (this->_map.get(target_x, target_y, 2) == FOOD);
+    int tile_val = this->_map.get(target_x, target_y, 2);
+    bool ate_food = (tile_val == FOOD || tile_val == FIRE_FOOD || tile_val == FROSTY_FOOD);
 
     // Move all existing segments forward by incrementing their values first
     // We need to do this in reverse order to avoid overwriting
@@ -288,6 +300,13 @@ int game_data::update_snake_position(int player_head)
 
     // Handle food consumption
     if (ate_food) {
+        if (tile_val == FIRE_FOOD)
+            this->_speed_boost_steps[player_number] += 3;
+        else if (tile_val == FROSTY_FOOD)
+        {
+            this->_frosty_steps[player_number] = 3;
+            this->_direction_moving_ice[player_number] = direction_moving;
+        }
         ft_achievement &apple =
             this->_character.get_achievements().at(ACH_APPLES_EATEN);
         int progress = apple.get_progress(ACH_GOAL_PRIMARY);
@@ -304,6 +323,13 @@ int game_data::update_snake_position(int player_head)
             this->spawn_food();
         }
     }
+    if (on_fire_next)
+    {
+        this->_speed_boost_steps[player_number] += 3;
+        this->_map.set(target_x, target_y, 0, GAME_TILE_EMPTY);
+        if (this->_additional_food_items)
+            this->spawn_fire_tile();
+    }
     return (0);
 }
 
@@ -315,18 +341,27 @@ int game_data::update_game_map(double deltaTime)
         SNAKE_HEAD_PLAYER_2,
         SNAKE_HEAD_PLAYER_3,
         SNAKE_HEAD_PLAYER_4};
-    const double moveInterval = 1.0 / this->_moves_per_second; // Moves per second is configurable
+    const double baseInterval = 1.0 / this->_moves_per_second; // Moves per second is configurable
     int i = 0;
     while (i < 4)
     {
         if (this->_snake_length[i] > 0)
         {
             this->_update_timer[i] += deltaTime;
-            while (this->_update_timer[i] >= moveInterval)
+            double interval = baseInterval;
+            if (this->_speed_boost_steps[i] > 0)
+                interval /= 1.5;
+            while (this->_update_timer[i] >= interval)
             {
-                this->_update_timer[i] -= moveInterval;
+                this->_update_timer[i] -= interval;
+                bool boosted = (this->_speed_boost_steps[i] > 0);
                 if (this->update_snake_position(heads[i]))
                     ret = 1;
+                if (boosted && this->_speed_boost_steps[i] > 0)
+                    this->_speed_boost_steps[i]--;
+                interval = baseInterval;
+                if (this->_speed_boost_steps[i] > 0)
+                    interval /= 1.5;
             }
         }
         ++i;

--- a/graphics_libs/NCursesGraphics.cpp
+++ b/graphics_libs/NCursesGraphics.cpp
@@ -302,6 +302,9 @@ void NCursesGraphics::initializeColors() {
     init_pair(COLOR_ICE, COLOR_CYAN, COLOR_BLACK);
     init_pair(COLOR_BORDER, COLOR_BLUE, COLOR_BLACK);
     init_pair(COLOR_INFO, COLOR_MAGENTA, COLOR_BLACK);
+    init_pair(COLOR_FIRE_FOOD, COLOR_RED, COLOR_YELLOW);
+    init_pair(COLOR_FROSTY_FOOD, COLOR_CYAN, COLOR_WHITE);
+    init_pair(COLOR_FIRE_TILE, COLOR_RED, COLOR_BLACK);
 }
 
 void NCursesGraphics::drawInfo(const game_data& game) {
@@ -342,6 +345,10 @@ char NCursesGraphics::getCharFromGameTile(int x, int y, const game_data& game) {
     int layer2Value = game.get_map_value(x, y, 2);
     if (layer2Value == FOOD) {
         return '*';  // Food
+    } else if (layer2Value == FIRE_FOOD) {
+        return 'F';  // Fire food
+    } else if (layer2Value == FROSTY_FOOD) {
+        return 'I';  // Frosty food
     } else if (layer2Value == SNAKE_HEAD_PLAYER_1) {
         return '@';  // Snake head
     } else if (layer2Value > SNAKE_HEAD_PLAYER_1) {
@@ -354,6 +361,8 @@ char NCursesGraphics::getCharFromGameTile(int x, int y, const game_data& game) {
         return '#';  // Wall
     } else if (layer0Value == GAME_TILE_ICE) {
         return '~';  // Ice
+    } else if (layer0Value == GAME_TILE_FIRE) {
+        return '^';  // Fire tile
     }
 
     return ' ';  // Empty space
@@ -364,6 +373,10 @@ int NCursesGraphics::getColorFromGameTile(int x, int y, const game_data& game) {
     int layer2Value = game.get_map_value(x, y, 2);
     if (layer2Value == FOOD) {
         return COLOR_FOOD;
+    } else if (layer2Value == FIRE_FOOD) {
+        return COLOR_FIRE_FOOD;
+    } else if (layer2Value == FROSTY_FOOD) {
+        return COLOR_FROSTY_FOOD;
     } else if (layer2Value == SNAKE_HEAD_PLAYER_1) {
         return COLOR_SNAKE_HEAD;
     } else if (layer2Value > SNAKE_HEAD_PLAYER_1) {
@@ -376,6 +389,8 @@ int NCursesGraphics::getColorFromGameTile(int x, int y, const game_data& game) {
         return COLOR_WALL;
     } else if (layer0Value == GAME_TILE_ICE) {
         return COLOR_ICE;
+    } else if (layer0Value == GAME_TILE_FIRE) {
+        return COLOR_FIRE_TILE;
     }
 
     return 0;  // Default color

--- a/graphics_libs/NCursesGraphics.hpp
+++ b/graphics_libs/NCursesGraphics.hpp
@@ -53,7 +53,10 @@ private:
         COLOR_WALL = 4,
         COLOR_ICE = 5,
         COLOR_BORDER = 6,
-        COLOR_INFO = 7
+        COLOR_INFO = 7,
+        COLOR_FIRE_FOOD = 8,
+        COLOR_FROSTY_FOOD = 9,
+        COLOR_FIRE_TILE = 10
     };
 
     // Helper methods

--- a/graphics_libs/SDL2Graphics.cpp
+++ b/graphics_libs/SDL2Graphics.cpp
@@ -12,6 +12,9 @@ const SDL2Graphics::Color SDL2Graphics::COLOR_BORDER(100, 100, 120);       // Li
 const SDL2Graphics::Color SDL2Graphics::COLOR_SNAKE_HEAD(50, 200, 50);     // Bright green
 const SDL2Graphics::Color SDL2Graphics::COLOR_SNAKE_BODY(30, 150, 30);     // Dark green
 const SDL2Graphics::Color SDL2Graphics::COLOR_FOOD(200, 50, 50);           // Red
+const SDL2Graphics::Color SDL2Graphics::COLOR_FIRE_FOOD(255, 120, 0);      // Orange
+const SDL2Graphics::Color SDL2Graphics::COLOR_FROSTY_FOOD(80, 170, 255);   // Light blue
+const SDL2Graphics::Color SDL2Graphics::COLOR_FIRE_TILE(200, 80, 20);      // Red-orange
 const SDL2Graphics::Color SDL2Graphics::COLOR_TEXT(255, 255, 255);         // White
 
 SDL2Graphics::SDL2Graphics()
@@ -163,6 +166,12 @@ void SDL2Graphics::render(const game_data& game) {
             if (layer2Value == FOOD) {
                 setDrawColor(COLOR_FOOD);
                 drawRect(pixelX + 2, pixelY + 2, cellSize - 4, cellSize - 4);
+            } else if (layer2Value == FIRE_FOOD) {
+                setDrawColor(COLOR_FIRE_FOOD);
+                drawRect(pixelX + 2, pixelY + 2, cellSize - 4, cellSize - 4);
+            } else if (layer2Value == FROSTY_FOOD) {
+                setDrawColor(COLOR_FROSTY_FOOD);
+                drawRect(pixelX + 2, pixelY + 2, cellSize - 4, cellSize - 4);
             } else if (layer2Value == SNAKE_HEAD_PLAYER_1) {
                 setDrawColor(COLOR_SNAKE_HEAD);
                 drawRect(pixelX, pixelY, cellSize, cellSize);
@@ -177,6 +186,9 @@ void SDL2Graphics::render(const game_data& game) {
                     drawRect(pixelX, pixelY, cellSize, cellSize);
                 } else if (layer0Value == GAME_TILE_ICE) {
                     setDrawColor(COLOR_BACKGROUND);
+                    drawRect(pixelX, pixelY, cellSize, cellSize);
+                } else if (layer0Value == GAME_TILE_FIRE) {
+                    setDrawColor(COLOR_FIRE_TILE);
                     drawRect(pixelX, pixelY, cellSize, cellSize);
                 }
                 // Empty space - no drawing needed

--- a/graphics_libs/SDL2Graphics.hpp
+++ b/graphics_libs/SDL2Graphics.hpp
@@ -59,6 +59,9 @@ private:
     static const Color COLOR_SNAKE_HEAD;
     static const Color COLOR_SNAKE_BODY;
     static const Color COLOR_FOOD;
+    static const Color COLOR_FIRE_FOOD;
+    static const Color COLOR_FROSTY_FOOD;
+    static const Color COLOR_FIRE_TILE;
     static const Color COLOR_TEXT;
 
     // Helper methods


### PR DESCRIPTION
## Summary
- Add board fire tile that speeds snake for three steps
- Spawn fire tile when additional items are enabled
- Render fire tile in NCurses and SDL2 graphics

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_68a9d3b8ad088331aad63c854b07bff0