### PR TITLE
Add helpers for reading files and validate custom map paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,9 @@ endif
 NAME        = nibbler$(EXE_EXT)
 NAME_DEBUG  = nibbler_debug$(EXE_EXT)
 
-HEADER      = game_data.hpp IGraphicsLibrary.hpp LibraryManager.hpp GameEngine.hpp MenuSystem.hpp \
+HEADER      = game_data.hpp IGraphicsLibrary.hpp LibraryManager.hpp GameEngine.hpp MenuSystem.hpp file_utils.hpp map_validation.hpp \
 
-SRC         = game_data_core.cpp game_data_board.cpp game_data_movement.cpp game_data_io.cpp main.cpp LibraryManager.cpp GameEngine.cpp MenuSystem.cpp \
+SRC         = game_data_core.cpp game_data_board.cpp game_data_movement.cpp game_data_io.cpp file_utils.cpp map_validation.cpp main.cpp LibraryManager.cpp GameEngine.cpp MenuSystem.cpp \
 
 CC          = g++
 

--- a/file_utils.cpp
+++ b/file_utils.cpp
@@ -1,0 +1,195 @@
+#include "file_utils.hpp"
+#include "game_data.hpp"
+#include "map_validation.hpp"
+#include <fcntl.h>
+#include <unistd.h>
+#include <cstdio>
+#include <cstdlib>
+#include <vector>
+#include <string>
+#include <algorithm>
+#include <cstring>
+
+int open_file_read(const char *path) {
+    if (!path) {
+        return -1;
+    }
+    return open(path, O_RDONLY);
+}
+
+char **read_file_lines(const char *path) {
+    int fd = open_file_read(path);
+    if (fd < 0) {
+        return nullptr;
+    }
+    FILE *fp = fdopen(fd, "r");
+    if (!fp) {
+        close(fd);
+        return nullptr;
+    }
+    std::vector<std::string> lines;
+    char *buffer = nullptr;
+    size_t buf_size = 0;
+    ssize_t line_len;
+    while ((line_len = getline(&buffer, &buf_size, fp)) != -1) {
+        if (line_len > 0 && buffer[line_len - 1] == '\n') {
+            buffer[line_len - 1] = '\0';
+        }
+        lines.emplace_back(buffer);
+    }
+    free(buffer);
+    fclose(fp);
+
+    char **result = new char *[lines.size() + 1];
+    for (size_t i = 0; i < lines.size(); ++i) {
+        result[i] = new char[lines[i].size() + 1];
+        std::copy(lines[i].begin(), lines[i].end(), result[i]);
+        result[i][lines[i].size()] = '\0';
+    }
+    result[lines.size()] = nullptr;
+    return result;
+}
+
+int read_game_rules(const char *path, game_rules &rules) {
+    rules.error = 0;
+    rules.snake_length = 4;
+    int fd = open_file_read(path);
+    if (fd < 0) {
+        rules.error = 1;
+        return -1;
+    }
+    FILE *fp = fdopen(fd, "r");
+    if (!fp) {
+        close(fd);
+        rules.error = 1;
+        return -1;
+    }
+    char *line = nullptr;
+    size_t buf_size = 0;
+    ssize_t line_len;
+    int found = 0;
+    bool in_map = false;
+    size_t map_width = 0;
+    int head_count = 0;
+    int body1_count = 0;
+    int body2_count = 0;
+    int body3_count = 0;
+    int head_x = -1, head_y = -1;
+    int body1_x = -1, body1_y = -1;
+    int body2_x = -1, body2_y = -1;
+    int body3_x = -1, body3_y = -1;
+    rules.custom_map.clear();
+    while ((line_len = getline(&line, &buf_size, fp)) != -1) {
+        if (line_len > 0 && line[line_len - 1] == '\n') {
+            line[line_len - 1] = '\0';
+        }
+        if (!in_map) {
+            if (std::strncmp(line, "WRAP_AROUND_EDGES=", 19) == 0) {
+                rules.wrap_around_edges = (line[19] == '1');
+                found++;
+            } else if (std::strncmp(line, "ADDITIONAL_FRUITS=", 20) == 0) {
+                rules.additional_fruits = (line[20] == '1');
+                found++;
+            } else if (std::strncmp(line, "CUSTOM_MAP=", 11) == 0) {
+                in_map = true;
+            }
+        } else {
+            size_t len = std::strlen(line);
+            if (len == 0) {
+                free(line);
+                fclose(fp);
+                rules.error = 1;
+                return -1;
+            }
+            if (map_width == 0)
+                map_width = len;
+            else if (len != map_width) {
+                free(line);
+                fclose(fp);
+                rules.error = 1;
+                return -1;
+            }
+            size_t y = rules.custom_map.size();
+            for (size_t i = 0; i < len; ++i) {
+                char c = line[i];
+                if (c != MAP_TILE_EMPTY && c != MAP_TILE_WALL &&
+                    c != MAP_TILE_ICE && c != MAP_TILE_FIRE &&
+                    c != MAP_TILE_SNAKE_HEAD &&
+                    c != MAP_TILE_SNAKE_BODY_1 &&
+                    c != MAP_TILE_SNAKE_BODY_2 &&
+                    c != MAP_TILE_SNAKE_BODY_3) {
+                    free(line);
+                    fclose(fp);
+                    rules.error = 1;
+                    return -1;
+                }
+                if (c == MAP_TILE_SNAKE_HEAD) {
+                    head_count++;
+                    if (head_count > 1) {
+                        free(line);
+                        fclose(fp);
+                        rules.error = 1;
+                        return -1;
+                    }
+                    head_x = static_cast<int>(i);
+                    head_y = static_cast<int>(y);
+                } else if (c == MAP_TILE_SNAKE_BODY_1) {
+                    body1_count++;
+                    if (body1_count > 1) {
+                        free(line);
+                        fclose(fp);
+                        rules.error = 1;
+                        return -1;
+                    }
+                    body1_x = static_cast<int>(i);
+                    body1_y = static_cast<int>(y);
+                } else if (c == MAP_TILE_SNAKE_BODY_2) {
+                    body2_count++;
+                    if (body2_count > 1) {
+                        free(line);
+                        fclose(fp);
+                        rules.error = 1;
+                        return -1;
+                    }
+                    body2_x = static_cast<int>(i);
+                    body2_y = static_cast<int>(y);
+                } else if (c == MAP_TILE_SNAKE_BODY_3) {
+                    body3_count++;
+                    if (body3_count > 1) {
+                        free(line);
+                        fclose(fp);
+                        rules.error = 1;
+                        return -1;
+                    }
+                    body3_x = static_cast<int>(i);
+                    body3_y = static_cast<int>(y);
+                }
+            }
+            rules.custom_map.push_back(std::string(line));
+        }
+    }
+    free(line);
+    fclose(fp);
+    if (in_map) {
+        if (map_width < 5 || rules.custom_map.size() < 5 || head_count != 1 ||
+            body1_count != 1 || body2_count != 1 || body3_count != 1 ||
+            head_count + body1_count + body2_count + body3_count !=
+                rules.snake_length ||
+            !validate_snake_chain(head_x, head_y, body1_x, body1_y, body2_x,
+                                  body2_y, body3_x, body3_y, map_width,
+                                  rules.custom_map.size(),
+                                  rules.wrap_around_edges) ||
+            !validate_map_path(rules.custom_map, rules.wrap_around_edges) ||
+            !validate_head_to_tail_path(rules.custom_map,
+                                        rules.wrap_around_edges, head_x,
+                                        head_y, body3_x, body3_y)) {
+            rules.error = 1;
+            return -1;
+        }
+    }
+    if (found < 2) {
+        rules.error = 1;
+        return -1;
+    }
+    return 0;
+}

--- a/file_utils.hpp
+++ b/file_utils.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <vector>
+#include <string>
+
+int open_file_read(const char *path);
+char **read_file_lines(const char *path);
+
+struct game_rules {
+    int error;
+    int wrap_around_edges;
+    int additional_fruits;
+    int snake_length;
+    std::vector<std::string> custom_map;
+};
+
+int read_game_rules(const char *path, game_rules &rules);

--- a/game_data.hpp
+++ b/game_data.hpp
@@ -11,6 +11,15 @@
 #define GAME_TILE_ICE 2
 #define GAME_TILE_FIRE 3
 
+#define MAP_TILE_EMPTY       '0'
+#define MAP_TILE_WALL        '1'
+#define MAP_TILE_ICE         '2'
+#define MAP_TILE_FIRE        '3'
+#define MAP_TILE_SNAKE_HEAD  '4'
+#define MAP_TILE_SNAKE_BODY_1 '5'
+#define MAP_TILE_SNAKE_BODY_2 '6'
+#define MAP_TILE_SNAKE_BODY_3 '7'
+
 #define SNAKE_HEAD_PLAYER_1 1000001
 #define SNAKE_HEAD_PLAYER_2 2000001
 #define SNAKE_HEAD_PLAYER_3 3000001

--- a/map_validation.cpp
+++ b/map_validation.cpp
@@ -1,0 +1,206 @@
+#include "map_validation.hpp"
+#include "game_data.hpp"
+#include <queue>
+#include <utility>
+#include <cstdlib>
+
+static bool locate_head_and_total(const std::vector<std::string> &map,
+                                  int &head_x, int &head_y, int &total) {
+    size_t height = map.size();
+    if (height == 0)
+        return false;
+    size_t width = map[0].size();
+    head_x = -1;
+    head_y = -1;
+    total = 0;
+    for (size_t y = 0; y < height; ++y) {
+        for (size_t x = 0; x < width; ++x) {
+            char c = map[y][x];
+            if (c != MAP_TILE_WALL)
+                total++;
+            if (c == MAP_TILE_SNAKE_HEAD) {
+                head_x = static_cast<int>(x);
+                head_y = static_cast<int>(y);
+            }
+        }
+    }
+    return head_x >= 0 && head_y >= 0;
+}
+
+static void process_direction(
+    const std::vector<std::string> &map, bool wrap_edges, int width, int height,
+    int x, int y, int dir, std::vector<std::vector<bool> > &visited,
+    std::vector<std::vector<bool> > &queued,
+    std::queue<std::pair<int, int> > &q, int &visited_count) {
+    const int dx[4] = {0, 1, 0, -1};
+    const int dy[4] = {-1, 0, 1, 0};
+    int nx = x;
+    int ny = y;
+    while (true) {
+        int tx = nx + dx[dir];
+        int ty = ny + dy[dir];
+        if (wrap_edges) {
+            if (tx < 0)
+                tx = width - 1;
+            else if (tx >= width)
+                tx = 0;
+            if (ty < 0)
+                ty = height - 1;
+            else if (ty >= height)
+                ty = 0;
+        } else {
+            if (tx < 0 || ty < 0 || tx >= width || ty >= height)
+                break;
+        }
+        char tile = map[ty][tx];
+        if (tile == MAP_TILE_WALL || visited[ty][tx])
+            break;
+        visited[ty][tx] = true;
+        visited_count++;
+        nx = tx;
+        ny = ty;
+        if (tile != MAP_TILE_ICE) {
+            if (!queued[ny][nx]) {
+                q.emplace(nx, ny);
+                queued[ny][nx] = true;
+            }
+            break;
+        }
+    }
+}
+
+static bool bfs_visit_all(const std::vector<std::string> &map, bool wrap_edges,
+                          int head_x, int head_y, int total) {
+    size_t height = map.size();
+    size_t width = map[0].size();
+    std::vector<std::vector<bool> > visited(height,
+                                            std::vector<bool>(width, false));
+    std::vector<std::vector<bool> > queued(height,
+                                           std::vector<bool>(width, false));
+    std::queue<std::pair<int, int> > q;
+    q.emplace(head_x, head_y);
+    queued[head_y][head_x] = true;
+    visited[head_y][head_x] = true;
+    int visited_count = 1;
+    for (; !q.empty(); q.pop()) {
+        int x = q.front().first;
+        int y = q.front().second;
+        for (int dir = 0; dir < 4; ++dir)
+            process_direction(map, wrap_edges, static_cast<int>(width),
+                              static_cast<int>(height), x, y, dir, visited,
+                              queued, q, visited_count);
+    }
+    return visited_count == total;
+}
+
+bool validate_map_path(const std::vector<std::string> &map, bool wrap_edges) {
+    int head_x, head_y, total;
+    if (!locate_head_and_total(map, head_x, head_y, total))
+        return false;
+    return bfs_visit_all(map, wrap_edges, head_x, head_y, total);
+}
+
+static bool dfs_return_path(const std::vector<std::string> &map, bool wrap_edges,
+                            int x, int y, int tail_x, int tail_y,
+                            int visited_count, int total,
+                            std::vector<std::vector<bool> > &visited) {
+    if (x == tail_x && y == tail_y)
+        return visited_count == total;
+    const int dx[4] = {0, 1, 0, -1};
+    const int dy[4] = {-1, 0, 1, 0};
+    size_t width = map[0].size();
+    size_t height = map.size();
+    for (int dir = 0; dir < 4; ++dir) {
+        int nx = x;
+        int ny = y;
+        std::vector<std::pair<int, int> > path;
+        bool invalid = false;
+        while (true) {
+            int tx = nx + dx[dir];
+            int ty = ny + dy[dir];
+            if (wrap_edges) {
+                if (tx < 0)
+                    tx = static_cast<int>(width) - 1;
+                else if (tx >= static_cast<int>(width))
+                    tx = 0;
+                if (ty < 0)
+                    ty = static_cast<int>(height) - 1;
+                else if (ty >= static_cast<int>(height))
+                    ty = 0;
+            } else {
+                if (tx < 0 || ty < 0 || tx >= static_cast<int>(width) ||
+                    ty >= static_cast<int>(height)) {
+                    invalid = true;
+                    break;
+                }
+            }
+            char tile = map[ty][tx];
+            if (tile == MAP_TILE_WALL || visited[ty][tx]) {
+                invalid = true;
+                break;
+            }
+            path.emplace_back(tx, ty);
+            nx = tx;
+            ny = ty;
+            if (nx == tail_x && ny == tail_y) {
+                if (visited_count + static_cast<int>(path.size()) == total)
+                    return true;
+                invalid = true;
+                break;
+            }
+            if (tile != MAP_TILE_ICE)
+                break;
+        }
+        if (invalid || path.empty())
+            continue;
+        for (size_t i = 0; i < path.size(); ++i)
+            visited[path[i].second][path[i].first] = true;
+        if (dfs_return_path(map, wrap_edges, nx, ny, tail_x, tail_y,
+                            visited_count + static_cast<int>(path.size()),
+                            total, visited))
+            return true;
+        for (size_t i = 0; i < path.size(); ++i)
+            visited[path[i].second][path[i].first] = false;
+    }
+    return false;
+}
+
+bool validate_head_to_tail_path(const std::vector<std::string> &map,
+                                bool wrap_edges, int head_x, int head_y,
+                                int tail_x, int tail_y) {
+    size_t height = map.size();
+    if (height == 0)
+        return false;
+    size_t width = map[0].size();
+    int total = 0;
+    for (size_t y = 0; y < height; ++y) {
+        for (size_t x = 0; x < width; ++x) {
+            if (map[y][x] != MAP_TILE_WALL)
+                total++;
+        }
+    }
+    std::vector<std::vector<bool> > visited(height,
+                                            std::vector<bool>(width, false));
+    visited[head_y][head_x] = true;
+    return dfs_return_path(map, wrap_edges, head_x, head_y, tail_x, tail_y, 1,
+                           total, visited);
+}
+
+bool validate_snake_chain(int hx, int hy, int b1x, int b1y, int b2x, int b2y,
+                          int b3x, int b3y, size_t width, size_t height,
+                          bool wrap_edges) {
+    auto adjacent = [&](int ax, int ay, int bx, int by) {
+        int dx = std::abs(ax - bx);
+        int dy = std::abs(ay - by);
+        if (wrap_edges) {
+            if (dx == static_cast<int>(width) - 1)
+                dx = 1;
+            if (dy == static_cast<int>(height) - 1)
+                dy = 1;
+        }
+        return dx + dy == 1;
+    };
+    return adjacent(hx, hy, b1x, b1y) &&
+           adjacent(b1x, b1y, b2x, b2y) &&
+           adjacent(b2x, b2y, b3x, b3y);
+}

--- a/map_validation.hpp
+++ b/map_validation.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <vector>
+#include <string>
+
+bool validate_map_path(const std::vector<std::string> &map, bool wrap_edges);
+bool validate_head_to_tail_path(const std::vector<std::string> &map,
+                                bool wrap_edges, int head_x, int head_y,
+                                int tail_x, int tail_y);
+bool validate_snake_chain(int hx, int hy, int b1x, int b1y,
+                          int b2x, int b2y, int b3x, int b3y,
+                          size_t width, size_t height, bool wrap_edges);


### PR DESCRIPTION
## Summary
- reject custom maps immediately when snake head or body tiles appear more than once
- refactor full-path validator into static helpers for locating the head and performing BFS traversal

## Testing
- `make` *(fails: libft/Game/character.hpp: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b438d03714833191cba65d838313c0