### PR TITLE
Improve map path checking efficiency

### DIFF
--- a/map_validation.cpp
+++ b/map_validation.cpp
@@ -3,6 +3,7 @@
 #include <queue>
 #include <utility>
 #include <cstdlib>
+#include <algorithm>
 
 static bool locate_head_and_total(const std::vector<std::string> &map,
                                   int &head_x, int &head_y, int &total) {
@@ -100,21 +101,101 @@ bool validate_map_path(const std::vector<std::string> &map, bool wrap_edges) {
     return bfs_visit_all(map, wrap_edges, head_x, head_y, total);
 }
 
+static int count_free_neighbors(
+    const std::vector<std::string> &map, bool wrap_edges, int width, int height,
+    int x, int y, const std::vector<std::vector<bool> > &visited) {
+    const int dx[4] = {0, 1, 0, -1};
+    const int dy[4] = {-1, 0, 1, 0};
+    int count = 0;
+    for (int dir = 0; dir < 4; ++dir) {
+        int nx = x + dx[dir];
+        int ny = y + dy[dir];
+        if (wrap_edges) {
+            if (nx < 0)
+                nx = width - 1;
+            else if (nx >= width)
+                nx = 0;
+            if (ny < 0)
+                ny = height - 1;
+            else if (ny >= height)
+                ny = 0;
+        } else {
+            if (nx < 0 || ny < 0 || nx >= width || ny >= height)
+                continue;
+        }
+        if (map[ny][nx] != MAP_TILE_WALL && !visited[ny][nx])
+            count++;
+    }
+    return count;
+}
+
+static bool remaining_connected(
+    const std::vector<std::string> &map, bool wrap_edges, int width, int height,
+    const std::vector<std::vector<bool> > &visited, int tail_x, int tail_y,
+    int remaining) {
+    if (remaining == 0)
+        return true;
+    if (visited[tail_y][tail_x])
+        return false;
+    std::queue<std::pair<int, int> > q;
+    std::vector<std::vector<bool> > seen(height,
+                                         std::vector<bool>(width, false));
+    q.emplace(tail_x, tail_y);
+    seen[tail_y][tail_x] = true;
+    int count = 0;
+    const int dx[4] = {0, 1, 0, -1};
+    const int dy[4] = {-1, 0, 1, 0};
+    for (; !q.empty(); q.pop()) {
+        int x = q.front().first;
+        int y = q.front().second;
+        count++;
+        for (int dir = 0; dir < 4; ++dir) {
+            int nx = x + dx[dir];
+            int ny = y + dy[dir];
+            if (wrap_edges) {
+                if (nx < 0)
+                    nx = width - 1;
+                else if (nx >= width)
+                    nx = 0;
+                if (ny < 0)
+                    ny = height - 1;
+                else if (ny >= height)
+                    ny = 0;
+            } else {
+                if (nx < 0 || ny < 0 || nx >= width || ny >= height)
+                    continue;
+            }
+            if (seen[ny][nx] || visited[ny][nx] ||
+                map[ny][nx] == MAP_TILE_WALL)
+                continue;
+            seen[ny][nx] = true;
+            q.emplace(nx, ny);
+        }
+    }
+    return count == remaining;
+}
+
 static bool dfs_return_path(const std::vector<std::string> &map, bool wrap_edges,
                             int x, int y, int tail_x, int tail_y,
                             int visited_count, int total,
                             std::vector<std::vector<bool> > &visited) {
     if (x == tail_x && y == tail_y)
         return visited_count == total;
-    const int dx[4] = {0, 1, 0, -1};
-    const int dy[4] = {-1, 0, 1, 0};
     size_t width = map[0].size();
     size_t height = map.size();
+    struct Move {
+        int nx;
+        int ny;
+        std::vector<std::pair<int, int> > path;
+        int neigh;
+    };
+    std::vector<Move> moves;
+    const int dx[4] = {0, 1, 0, -1};
+    const int dy[4] = {-1, 0, 1, 0};
     for (int dir = 0; dir < 4; ++dir) {
         int nx = x;
         int ny = y;
         std::vector<std::pair<int, int> > path;
-        bool invalid = false;
         while (true) {
             int tx = nx + dx[dir];
             int ty = ny + dy[dir];
@@ -129,38 +210,53 @@ static bool dfs_return_path(const std::vector<std::string> &map, bool wrap_edges
                     ty = 0;
             } else {
                 if (tx < 0 || ty < 0 || tx >= static_cast<int>(width) ||
-                    ty >= static_cast<int>(height)) {
-                    invalid = true;
+                    ty >= static_cast<int>(height))
                     break;
-                }
             }
             char tile = map[ty][tx];
-            if (tile == MAP_TILE_WALL || visited[ty][tx]) {
-                invalid = true;
+            if (tile == MAP_TILE_WALL || visited[ty][tx])
                 break;
-            }
             path.emplace_back(tx, ty);
             nx = tx;
             ny = ty;
             if (nx == tail_x && ny == tail_y) {
                 if (visited_count + static_cast<int>(path.size()) == total)
                     return true;
-                invalid = true;
+                path.clear();
                 break;
             }
             if (tile != MAP_TILE_ICE)
                 break;
         }
-        if (invalid || path.empty())
+        if (path.empty())
             continue;
-        for (size_t i = 0; i < path.size(); ++i)
-            visited[path[i].second][path[i].first] = true;
-        if (dfs_return_path(map, wrap_edges, nx, ny, tail_x, tail_y,
-                            visited_count + static_cast<int>(path.size()),
-                            total, visited))
+        for (const auto &p : path)
+            visited[p.second][p.first] = true;
+        int neigh = count_free_neighbors(map, wrap_edges, static_cast<int>(width),
+                                         static_cast<int>(height), nx, ny,
+                                         visited);
+        for (const auto &p : path)
+            visited[p.second][p.first] = false;
+        if (neigh == 0)
+            continue;
+        moves.push_back({nx, ny, path, neigh});
+    }
+    std::sort(moves.begin(), moves.end(),
+              [](const Move &a, const Move &b) { return a.neigh < b.neigh; });
+    for (const auto &m : moves) {
+        for (const auto &p : m.path)
+            visited[p.second][p.first] = true;
+        int new_count = visited_count + static_cast<int>(m.path.size());
+        int remaining = total - new_count;
+        bool ok = remaining_connected(map, wrap_edges, static_cast<int>(width),
+                                      static_cast<int>(height), visited,
+                                      tail_x, tail_y, remaining);
+        if (ok &&
+            dfs_return_path(map, wrap_edges, m.nx, m.ny, tail_x, tail_y,
+                            new_count, total, visited))
             return true;
-        for (size_t i = 0; i < path.size(); ++i)
-            visited[path[i].second][path[i].first] = false;
+        for (const auto &p : m.path)
+            visited[p.second][p.first] = false;
     }
     return false;
 }
@@ -173,12 +269,10 @@ bool validate_head_to_tail_path(const std::vector<std::string> &map,
         return false;
     size_t width = map[0].size();
     int total = 0;
-    for (size_t y = 0; y < height; ++y) {
-        for (size_t x = 0; x < width; ++x) {
+    for (size_t y = 0; y < height; ++y)
+        for (size_t x = 0; x < width; ++x)
             if (map[y][x] != MAP_TILE_WALL)
                 total++;
-        }
-    }
     std::vector<std::vector<bool> > visited(height,
                                             std::vector<bool>(width, false));
     visited[head_y][head_x] = true;


### PR DESCRIPTION
## Summary
- Reintroduce head-to-tail validation using DFS with neighbor-degree ordering and connectivity pruning to avoid revisiting tiles
- Add helpers to count free neighbors and confirm remaining region is connected

## Testing
- `make` *(fails: libft/Game/character.hpp: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bdb05674a08331870852f2bb7326cb