### PR TITLE
Guard frosty fruit spawn logic

### DIFF
--- a/game_data.hpp
+++ b/game_data.hpp
@@ -113,6 +113,8 @@ class game_data
         int         is_valid_move(int player_head);
         int         update_snake_position(int player_head);
         void        spawn_fire_tile();
+        bool        can_spawn_frosty_food(int x, int y);
+        bool        is_tile_free(int &x, int &y) const;
 
         mutable int _error;
         int         _wrap_around_edges;


### PR DESCRIPTION
## Summary
- Ensure frosty fruit spawns only where the snake can approach from one side and slide two tiles in the opposite direction, accounting for ice tiles and walls
- Stop frosty fruit spawning when snakes occupy 60% or more of open tiles
- If a spot can't host frosty fruit, fall back to a coin toss between fiery and normal fruit

## Testing
- `make` *(fails: libft/Game/character.hpp: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bdc0c73c808331913e2b23284cd36f