### PR TITLE
Use nullptr instead of NULL

### DIFF
--- a/GameEngine.cpp
+++ b/GameEngine.cpp
@@ -130,7 +130,7 @@ void GameEngine::run() {
 }
 
 const char* GameEngine::getError() const {
-    return _errorMessage.empty() ? NULL : _errorMessage.c_str();
+    return _errorMessage.empty() ? nullptr : _errorMessage.c_str();
 }
 
 bool GameEngine::isInitialized() const {

--- a/IGraphicsLibrary.hpp
+++ b/IGraphicsLibrary.hpp
@@ -32,7 +32,7 @@ class IGraphicsLibrary {
         (void)fps;
     }
     virtual const char* getError() const {
-        return NULL;
+        return nullptr;
     }
     virtual void setMenuSystem(MenuSystem* menuSystem) {
         (void)menuSystem;

--- a/LibraryManager.cpp
+++ b/LibraryManager.cpp
@@ -27,7 +27,7 @@ int LibraryManager::loadLibrary(const std::string& libraryPath) {
     LibraryInfo libInfo;
     libInfo.handle = handle;
     libInfo.path = libraryPath;
-    libInfo.instance = NULL;
+    libInfo.instance = nullptr;
 
     // Load the required symbols
     if (!loadLibrarySymbols(libInfo)) {
@@ -97,7 +97,7 @@ IGraphicsLibrary* LibraryManager::getCurrentLibrary() const {
     if (_currentLibraryIndex >= 0 && _currentLibraryIndex < static_cast<int>(_libraries.size())) {
         return _libraries[_currentLibraryIndex].instance;
     }
-    return NULL;
+    return nullptr;
 }
 
 int LibraryManager::getCurrentLibraryIndex() const {
@@ -112,7 +112,7 @@ const char* LibraryManager::getLibraryName(int index) const {
     if (index >= 0 && index < static_cast<int>(_libraries.size())) {
         return _libraries[index].name.c_str();
     }
-    return NULL;
+    return nullptr;
 }
 
 const char* LibraryManager::getError() const {
@@ -168,11 +168,11 @@ bool LibraryManager::loadLibrarySymbols(LibraryInfo& libInfo) {
 void LibraryManager::cleanupLibrary(LibraryInfo& libInfo) {
     if (libInfo.instance && libInfo.destroyFunc) {
         libInfo.destroyFunc(libInfo.instance);
-        libInfo.instance = NULL;
+        libInfo.instance = nullptr;
     }
 
     if (libInfo.handle) {
         dlclose(libInfo.handle);
-        libInfo.handle = NULL;
+        libInfo.handle = nullptr;
     }
 }

--- a/game_data_movement.cpp
+++ b/game_data_movement.cpp
@@ -279,7 +279,7 @@ int game_data::update_snake_position(int player_head) {
 
     // Update tile stepping achievements
     {
-        ft_achievement *tile_ach = NULL;
+        ft_achievement *tile_ach = nullptr;
         if (tile_type == GAME_TILE_FIRE)
             tile_ach = &this->_character.get_achievements().at(ACH_TILE_FIRE_STEPS);
         else if (tile_type == GAME_TILE_ICE)

--- a/graphics_libs/include/OpenGLGraphics.hpp
+++ b/graphics_libs/include/OpenGLGraphics.hpp
@@ -63,8 +63,8 @@ class OpenGLGraphics : public IGraphicsLibrary {
 
   bool _fontInitialized;
   int _fontPixelSize = 24;
-  FT_Library _ftLibrary = NULL;
-  FT_Face _ftFace = NULL;
+  FT_Library _ftLibrary = nullptr;
+  FT_Face _ftFace = nullptr;
   std::map<char, Glyph> _glyphs; // Basic ASCII glyph cache
 
     // Window dimensions

--- a/graphics_libs/src/NCursesGraphics.cpp
+++ b/graphics_libs/src/NCursesGraphics.cpp
@@ -4,8 +4,8 @@
 
 NCursesGraphics::NCursesGraphics()
     : _initialized(false), _shouldContinue(true), _frameRate(60),
-      _gameWindow(NULL), _switchMessageTimer(0), _infoWindow(NULL),
-      _menuSystem(NULL) {
+      _gameWindow(nullptr), _switchMessageTimer(0), _infoWindow(nullptr),
+      _menuSystem(nullptr) {
     clearError();
 }
 
@@ -74,11 +74,11 @@ void NCursesGraphics::shutdown() {
     // Clean up windows
     if (_gameWindow) {
         delwin(_gameWindow);
-        _gameWindow = NULL;
+        _gameWindow = nullptr;
     }
     if (_infoWindow) {
         delwin(_infoWindow);
-        _infoWindow = NULL;
+        _infoWindow = nullptr;
     }
 
     // Restore terminal
@@ -289,7 +289,7 @@ void NCursesGraphics::setFrameRate(int fps) {
 }
 
 const char* NCursesGraphics::getError() const {
-    return _errorMessage.empty() ? NULL : _errorMessage.c_str();
+    return _errorMessage.empty() ? nullptr : _errorMessage.c_str();
 }
 
 // Private helper methods

--- a/graphics_libs/src/OpenGLGraphics.cpp
+++ b/graphics_libs/src/OpenGLGraphics.cpp
@@ -39,8 +39,8 @@ const OpenGLGraphics::Color OpenGLGraphics::ALT_COLOR_FOOD(0.92f, 0.51f, 0.14f);
 const OpenGLGraphics::Color OpenGLGraphics::ALT_COLOR_TEXT(0.94f, 0.94f, 0.94f);
 
 OpenGLGraphics::OpenGLGraphics()
-        : _window(NULL), _initialized(false), _shouldContinue(true), _targetFPS(60),
-            _menuSystem(NULL), _switchMessageTimer(0), _lastKeyPressed(GameKey::NONE), _keyConsumed(true),
+        : _window(nullptr), _initialized(false), _shouldContinue(true), _targetFPS(60),
+            _menuSystem(nullptr), _switchMessageTimer(0), _lastKeyPressed(GameKey::NONE), _keyConsumed(true),
             _fontInitialized(false) {
 }
 
@@ -70,7 +70,7 @@ int OpenGLGraphics::initialize() {
     glfwWindowHint(GLFW_RESIZABLE, GLFW_FALSE);
 
     // Create window
-    _window = glfwCreateWindow(WINDOW_WIDTH, WINDOW_HEIGHT, "Nibbler - OpenGL Graphics", NULL, NULL);
+    _window = glfwCreateWindow(WINDOW_WIDTH, WINDOW_HEIGHT, "Nibbler - OpenGL Graphics", nullptr, nullptr);
     if (!_window) {
         setError("Failed to create GLFW window");
         glfwTerminate();
@@ -127,13 +127,13 @@ void OpenGLGraphics::shutdown() {
 
     if (_window) {
         glfwDestroyWindow(_window);
-        _window = NULL;
+        _window = nullptr;
     }
 
     glfwTerminate();
 
     // Reset state
-    _menuSystem = NULL;
+    _menuSystem = nullptr;
     _switchMessage.clear();
     _switchMessageTimer = 0;
     _targetFPS = 60;
@@ -268,7 +268,7 @@ const char* OpenGLGraphics::getName() const {
 }
 
 const char* OpenGLGraphics::getError() const {
-    return _errorMessage.empty() ? NULL : _errorMessage.c_str();
+    return _errorMessage.empty() ? nullptr : _errorMessage.c_str();
 }
 
 void OpenGLGraphics::setFrameRate(int fps) {
@@ -427,7 +427,7 @@ bool OpenGLGraphics::initializeFonts() {
     if (!faceLoaded) {
         std::cerr << "[OpenGLGraphics] No suitable font file found" << std::endl;
         FT_Done_FreeType(_ftLibrary);
-        _ftLibrary = NULL;
+        _ftLibrary = nullptr;
         return false;
     }
 
@@ -448,12 +448,12 @@ bool OpenGLGraphics::loadFontFace(const std::string& path) {
     // Avoid italic/cursive styles if possible
     if (_ftFace->style_flags & FT_STYLE_FLAG_ITALIC) {
         FT_Done_Face(_ftFace);
-        _ftFace = NULL;
+        _ftFace = nullptr;
         return false; // try next candidate
     }
     if (FT_Set_Pixel_Sizes(_ftFace, 0, _fontPixelSize)) {
         FT_Done_Face(_ftFace);
-        _ftFace = NULL;
+        _ftFace = nullptr;
         return false;
     }
     std::cout << "[OpenGLGraphics] Loaded font: " << path << std::endl;
@@ -518,11 +518,11 @@ void OpenGLGraphics::shutdownFonts() {
 
     if (_ftFace) {
         FT_Done_Face(_ftFace);
-        _ftFace = NULL;
+        _ftFace = nullptr;
     }
     if (_ftLibrary) {
         FT_Done_FreeType(_ftLibrary);
-        _ftLibrary = NULL;
+        _ftLibrary = nullptr;
     }
     _fontInitialized = false;
 }

--- a/graphics_libs/src/RaylibGraphics.cpp
+++ b/graphics_libs/src/RaylibGraphics.cpp
@@ -28,7 +28,7 @@ const RaylibGraphics::Color RaylibGraphics::ALT_COLOR_FOOD(235, 130, 35, 255);
 const RaylibGraphics::Color RaylibGraphics::ALT_COLOR_TEXT(240, 240, 240, 255);
 
 RaylibGraphics::RaylibGraphics()
-    : _initialized(false), _shouldContinue(true), _targetFPS(60), _menuSystem(NULL), _switchMessageTimer(0) {}
+    : _initialized(false), _shouldContinue(true), _targetFPS(60), _menuSystem(nullptr), _switchMessageTimer(0) {}
 
 RaylibGraphics::~RaylibGraphics() {
     shutdown();
@@ -220,7 +220,7 @@ bool RaylibGraphics::shouldContinue() const {
 }
 
 const char* RaylibGraphics::getError() const {
-    return _errorMessage.empty() ? NULL : _errorMessage.c_str();
+    return _errorMessage.empty() ? nullptr : _errorMessage.c_str();
 }
 
 void RaylibGraphics::setFrameRate(int fps) {

--- a/graphics_libs/src/SDL2Graphics.cpp
+++ b/graphics_libs/src/SDL2Graphics.cpp
@@ -32,8 +32,8 @@ const SDL2Graphics::Color SDL2Graphics::COLOR_SELECTED_TEXT(255, 255, 255); // W
 
 SDL2Graphics::SDL2Graphics()
     : _initialized(false), _shouldContinue(true), _targetFPS(60), _frameDelay(1000 / 60),
-      _window(NULL), _renderer(NULL), _fontLarge(NULL), _fontMedium(NULL),
-      _fontSmall(NULL), _menuSystem(NULL), _switchMessageTimer(0) {
+      _window(nullptr), _renderer(nullptr), _fontLarge(nullptr), _fontMedium(nullptr),
+      _fontSmall(nullptr), _menuSystem(nullptr), _switchMessageTimer(0) {
 }
 
 SDL2Graphics::~SDL2Graphics() {
@@ -86,7 +86,7 @@ int SDL2Graphics::initialize() {
         if (!_renderer) {
             setError(std::string("Renderer could not be created: ") + SDL_GetError());
             SDL_DestroyWindow(_window);
-            _window = NULL;
+            _window = nullptr;
             TTF_Quit();
             SDL_Quit();
             return 1;
@@ -96,9 +96,9 @@ int SDL2Graphics::initialize() {
     // Initialize fonts
     if (!initializeFonts()) {
         SDL_DestroyRenderer(_renderer);
-        _renderer = NULL;
+        _renderer = nullptr;
         SDL_DestroyWindow(_window);
-        _window = NULL;
+        _window = nullptr;
         TTF_Quit();
         SDL_Quit();
         return 1;
@@ -136,13 +136,13 @@ void SDL2Graphics::shutdown() {
     // Destroy renderer
     if (_renderer) {
         SDL_DestroyRenderer(_renderer);
-        _renderer = NULL;
+        _renderer = nullptr;
     }
 
     // Destroy window and force it to close immediately
     if (_window) {
         SDL_DestroyWindow(_window);
-        _window = NULL;
+        _window = nullptr;
     }
 
     // Process events one more time after window destruction
@@ -319,7 +319,7 @@ bool SDL2Graphics::shouldContinue() const {
 }
 
 const char* SDL2Graphics::getError() const {
-    return _errorMessage.empty() ? NULL : _errorMessage.c_str();
+    return _errorMessage.empty() ? nullptr : _errorMessage.c_str();
 }
 
 void SDL2Graphics::setFrameRate(int fps) {
@@ -700,13 +700,13 @@ bool SDL2Graphics::initializeFonts() {
         "/usr/share/fonts/TTF/arial.ttf",
         // Fallback - try to find any reasonable font
         "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf",
-        NULL};
+        nullptr};
 
-    TTF_Font* testFont = NULL;
-    const char* selectedFontPath = NULL;
+    TTF_Font* testFont = nullptr;
+    const char* selectedFontPath = nullptr;
 
     // Find the first available font
-    for (int i = 0; fontPaths[i] != NULL; ++i) {
+    for (int i = 0; fontPaths[i] != nullptr; ++i) {
         testFont = TTF_OpenFont(fontPaths[i], 24);
         if (testFont) {
             selectedFontPath = fontPaths[i];
@@ -737,15 +737,15 @@ bool SDL2Graphics::initializeFonts() {
 void SDL2Graphics::shutdownFonts() {
     if (_fontLarge) {
         TTF_CloseFont(_fontLarge);
-        _fontLarge = NULL;
+        _fontLarge = nullptr;
     }
     if (_fontMedium) {
         TTF_CloseFont(_fontMedium);
-        _fontMedium = NULL;
+        _fontMedium = nullptr;
     }
     if (_fontSmall) {
         TTF_CloseFont(_fontSmall);
-        _fontSmall = NULL;
+        _fontSmall = nullptr;
     }
 }
 
@@ -791,10 +791,10 @@ void SDL2Graphics::drawTextWithFont(const std::string& text, int x, int y, TTF_F
     }
 
     int textWidth, textHeight;
-    SDL_QueryTexture(textTexture, NULL, NULL, &textWidth, &textHeight);
+    SDL_QueryTexture(textTexture, nullptr, nullptr, &textWidth, &textHeight);
 
     SDL_Rect destRect = {x, y, textWidth, textHeight};
-    SDL_RenderCopy(_renderer, textTexture, NULL, &destRect);
+    SDL_RenderCopy(_renderer, textTexture, nullptr, &destRect);
 
     SDL_DestroyTexture(textTexture);
 }

--- a/graphics_libs/src/SFMLGraphics.cpp
+++ b/graphics_libs/src/SFMLGraphics.cpp
@@ -30,7 +30,7 @@ const SFMLGraphics::Color SFMLGraphics::COLOR_SELECTED_TEXT(255, 255, 255); // W
 
 SFMLGraphics::SFMLGraphics()
     : _initialized(false), _shouldContinue(true), _targetFPS(60),
-      _window(NULL), _menuSystem(NULL), _switchMessageTimer(0) {
+      _window(nullptr), _menuSystem(nullptr), _switchMessageTimer(0) {
 }
 
 SFMLGraphics::~SFMLGraphics() {
@@ -57,7 +57,7 @@ int SFMLGraphics::initialize() {
     // Load font
     if (!initializeFont()) {
         delete _window;
-        _window = NULL;
+        _window = nullptr;
         return 1;
     }
 
@@ -108,7 +108,7 @@ void SFMLGraphics::shutdown() {
 
         // Delete the window object
         delete _window;
-        _window = NULL;
+        _window = nullptr;
 
         // Additional delay specifically for OpenGL context cleanup
         sf::sleep(sf::milliseconds(200)); // Increased from 150ms
@@ -130,7 +130,7 @@ void SFMLGraphics::shutdown() {
     _font = sf::Font();
 
     // Reset all other member variables to safe states
-    _menuSystem = NULL;
+    _menuSystem = nullptr;
     _switchMessage.clear();
     _switchMessageTimer = 0;
     _targetFPS = 60;
@@ -272,7 +272,7 @@ bool SFMLGraphics::shouldContinue() const {
 }
 
 const char* SFMLGraphics::getError() const {
-    return _errorMessage.empty() ? NULL : _errorMessage.c_str();
+    return _errorMessage.empty() ? nullptr : _errorMessage.c_str();
 }
 
 void SFMLGraphics::setFrameRate(int fps) {


### PR DESCRIPTION
## Summary
- Replace all usages of legacy NULL with modern C++ `nullptr` across engine, library management, and graphics modules for safer pointer semantics.

## Testing
- `make` *(fails: libft/Game/character.hpp: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c57dfb90c48331a2ebec5570c86db2