### PR TITLE
Refactor file reading to use streams and vectors

### DIFF
--- a/file_utils.hpp
+++ b/file_utils.hpp
@@ -2,11 +2,11 @@
 
 #include <vector>
 #include <string>
+#include <optional>
 
 class game_data;
 
-int open_file_read(const char *path);
-char **read_file_lines(const char *path);
+std::optional<std::vector<std::string>> read_file_lines(const char *path);
 
 struct game_rules {
     int error;


### PR DESCRIPTION
## Summary
- Read file lines with `std::ifstream` and return `std::optional<std::vector<std::string>>`
- Simplify game rule parsing to use the new vector directly and drop manual memory management

## Testing
- `make` *(fails: libft/Game/character.hpp: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c580f2d6048331b116cbecdd26bc74