### PR TITLE
Add missing algorithm include to GameEngine

### DIFF
--- a/GameEngine.cpp
+++ b/GameEngine.cpp
@@ -4,6 +4,7 @@
 #include <chrono>
 #include <thread>
 #include <cstdlib>
+#include <algorithm>
 #include "file_utils.hpp" // for game_rules & rule loading
 
 static const char* slotName(int slot) {


### PR DESCRIPTION
## Summary
- include `<algorithm>` in `GameEngine.cpp` to ensure standard algorithms are available explicitly

## Testing
- make

------
https://chatgpt.com/codex/tasks/task_e_68e02c3e5128833182739f571dae7a04