### PR TITLE
Fix player index mapping and add movement tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,7 @@ DLLIBS_DIR      = ./dllibs
 
 TEST_DIR        = Test
 TEST_BIN        = $(TEST_DIR)/map_parsing_tests
+TEST_MOVEMENT_BIN = $(TEST_DIR)/movement_tests
 
 # Export absolute paths to sub-makes so graphics_libs can use correct paths
 export OBJ_DIR := $(abspath $(OBJ_DIR))
@@ -153,9 +154,15 @@ both: all debug
 
 re_both: re both
 
-tests: $(TEST_DIR)/map_parsing_tests.cpp map_validation.cpp
+tests: $(LIBFT) $(TEST_DIR)/map_parsing_tests.cpp map_validation.cpp $(TEST_DIR)/movement_tests.cpp \
+game_data_core.cpp game_data_board.cpp game_data_movement.cpp game_data_io.cpp
 	$(CC) $(CFLAGS) $(TEST_DIR)/map_parsing_tests.cpp -o $(TEST_BIN)
 	./$(TEST_BIN)
 	$(RM) $(TEST_BIN)
+	$(CC) $(CFLAGS) $(TEST_DIR)/movement_tests.cpp game_data_core.cpp \
+	game_data_board.cpp game_data_movement.cpp game_data_io.cpp \
+	-o $(TEST_MOVEMENT_BIN) $(LIBFT)
+	./$(TEST_MOVEMENT_BIN)
+	$(RM) $(TEST_MOVEMENT_BIN)
 
 .PHONY: all dirs clean fclean re debug both re_both graphics_libs graphics_re tests

--- a/Test/movement_tests.cpp
+++ b/Test/movement_tests.cpp
@@ -1,0 +1,76 @@
+#include "../game_data.hpp"
+
+#include <cassert>
+#include <iostream>
+
+static void clear_board(game_data &data)
+{
+    for (size_t y = 0; y < data.get_height(); ++y)
+    {
+        for (size_t x = 0; x < data.get_width(); ++x)
+        {
+            data.set_map_value(static_cast<int>(x), static_cast<int>(y), 0, GAME_TILE_EMPTY);
+            data.set_map_value(static_cast<int>(x), static_cast<int>(y), 1, 0);
+            data.set_map_value(static_cast<int>(x), static_cast<int>(y), 2, 0);
+        }
+    }
+}
+
+static void place_head(game_data &data, int head_value, int x, int y)
+{
+    data.set_map_value(x, y, 0, GAME_TILE_EMPTY);
+    data.set_map_value(x, y, 2, head_value);
+}
+
+static void place_wall(game_data &data, int x, int y)
+{
+    data.set_map_value(x, y, 2, 0);
+    data.set_map_value(x, y, 0, GAME_TILE_WALL);
+}
+
+static void ensure_empty(game_data &data, int x, int y)
+{
+    data.set_map_value(x, y, 0, GAME_TILE_EMPTY);
+    data.set_map_value(x, y, 2, 0);
+}
+
+static void expect_valid_move(game_data &data, int head_value, const char *label)
+{
+    int result = data.test_is_valid_move(head_value);
+    if (result != 0)
+        std::cerr << label << " should have been valid but returned " << result << '\n';
+    assert(result == 0);
+}
+
+int main()
+{
+    game_data data(5, 5);
+    clear_board(data);
+
+    // Set player 1 to move upward so aliasing would fail for other players
+    data.set_direction_moving(0, DIRECTION_UP);
+
+    // Player 2: move right into an empty tile, but up is blocked by a wall
+    place_head(data, SNAKE_HEAD_PLAYER_2, 1, 1);
+    place_wall(data, 1, 0);
+    ensure_empty(data, 2, 1);
+    data.set_direction_moving(1, DIRECTION_RIGHT);
+    expect_valid_move(data, SNAKE_HEAD_PLAYER_2, "player 2 move");
+
+    // Player 3: move down into an empty tile, but up is blocked by a wall
+    place_head(data, SNAKE_HEAD_PLAYER_3, 3, 1);
+    place_wall(data, 3, 0);
+    ensure_empty(data, 3, 2);
+    data.set_direction_moving(2, DIRECTION_DOWN);
+    expect_valid_move(data, SNAKE_HEAD_PLAYER_3, "player 3 move");
+
+    // Player 4: move left into an empty tile, but up is blocked by a wall
+    place_head(data, SNAKE_HEAD_PLAYER_4, 2, 3);
+    place_wall(data, 2, 2);
+    ensure_empty(data, 1, 3);
+    data.set_direction_moving(3, DIRECTION_LEFT);
+    expect_valid_move(data, SNAKE_HEAD_PLAYER_4, "player 4 move");
+
+    std::cout << "Movement tests passed" << std::endl;
+    return 0;
+}

--- a/game_data_movement.cpp
+++ b/game_data_movement.cpp
@@ -17,7 +17,7 @@ t_coordinates game_data::get_head_coordinate(int head_to_find) {
 }
 
 int game_data::determine_player_number(int player_head) {
-    return ((player_head % 1000000) - 1);
+    return ((player_head / 1000000) - 1);
 }
 
 bool game_data::advance_wrap_target(int direction, int &target_x, int &target_y) const {
@@ -131,7 +131,7 @@ int game_data::is_valid_move(int player_head) {
     }
 
     int target_val = this->_map.get(target_x, target_y, 2);
-    int offset = (player_head / 1000000) * 1000000;
+    int offset = (player_number + 1) * 1000000;
     int tail_value = offset + this->_snake_length[player_number];
     if (target_val != 0 && target_val != FOOD && target_val != FIRE_FOOD && target_val != FROSTY_FOOD && target_val != tail_value)
         return (1);
@@ -302,7 +302,7 @@ int game_data::update_snake_position(int player_head) {
         if (this->_frosty_steps[player_number] == 0 && !on_ice_next)
             this->_direction_moving_ice[player_number] = 0;
     }
-    int offset = (player_head / 1000000) * 1000000;
+    int offset = (player_number + 1) * 1000000;
     int tile_val = this->_map.get(target_x, target_y, 2);
     bool ate_food = (tile_val == FOOD || tile_val == FIRE_FOOD || tile_val == FROSTY_FOOD);
     bool target_is_tail = (tile_val == offset + this->_snake_length[player_number]);


### PR DESCRIPTION
## Summary
- correct the player index calculation for snake heads and use the resolved index when deriving map offsets
- add a movement unit test that exercises player heads 2 through 4 to guard against index aliasing
- extend the test harness to build and run the new movement test alongside the existing parser tests

## Testing
- make tests

------
https://chatgpt.com/codex/tasks/task_e_68e02e28dc488331bcc2d8e9bb46a5ec