### PR TITLE
Sync snake length with loaded bonus maps

### DIFF
--- a/Test/bonus_map_persistence_tests.cpp
+++ b/Test/bonus_map_persistence_tests.cpp
@@ -49,7 +49,35 @@ static void test_bonus_map_persists_across_game_over() {
     std::cout << "Bonus map persistence regression test passed" << std::endl;
 }
 
+static void test_snake_length_resets_after_game_over() {
+    GameEngine engine(10, 10);
+    int loadResult = engine.loadBonusMap("Test/maps/persistence_bonus.nib");
+    assert(loadResult == 0);
+    int startingLength = engine._gameData.get_snake_length(0);
+    assert(startingLength > 0);
+
+    engine._gameData.set_player_snake_length(0, startingLength + 5);
+    engine._gameData.set_player_snake_length(1, 3);
+    engine._gameData.set_player_snake_length(2, 2);
+    engine._gameData.set_player_snake_length(3, 1);
+
+    assert(engine._gameData.get_snake_length(0) == startingLength + 5);
+    assert(engine._gameData.get_snake_length(1) == 3);
+    assert(engine._gameData.get_snake_length(2) == 2);
+    assert(engine._gameData.get_snake_length(3) == 1);
+
+    engine.handleGameOver();
+
+    assert(engine._gameData.get_snake_length(0) == startingLength);
+    assert(engine._gameData.get_snake_length(1) == 0);
+    assert(engine._gameData.get_snake_length(2) == 0);
+    assert(engine._gameData.get_snake_length(3) == 0);
+
+    std::cout << "Snake length reset regression test passed" << std::endl;
+}
+
 int main() {
     test_bonus_map_persists_across_game_over();
+    test_snake_length_resets_after_game_over();
     return 0;
 }

--- a/file_utils.cpp
+++ b/file_utils.cpp
@@ -200,6 +200,7 @@ int load_rules_into_game_data(game_data &data, const game_rules &rules) {
     if (!rules.custom_map.empty()) {
         size_t width = rules.custom_map[0].size();
         size_t height = rules.custom_map.size();
+        int player1Segments = 0;
         for (size_t y = 0; y < height; ++y) {
             for (size_t x = 0; x < width; ++x) {
                 char c = rules.custom_map[y][x];
@@ -223,8 +224,14 @@ int load_rules_into_game_data(game_data &data, const game_rules &rules) {
                     snake = SNAKE_HEAD_PLAYER_1 + 3;
                 data.set_map_value(static_cast<int>(x), static_cast<int>(y), 2,
                                     snake);
+                if (snake >= SNAKE_HEAD_PLAYER_1 && snake < SNAKE_HEAD_PLAYER_2)
+                    ++player1Segments;
             }
         }
+
+        data.set_player_snake_length(0, player1Segments);
+        for (int player = 1; player < 4; ++player)
+            data.set_player_snake_length(player, 0);
 
         // After applying the map, ensure at least one food spawns at a random empty cell
         std::vector<std::pair<int,int>> empties;

--- a/game_data.hpp
+++ b/game_data.hpp
@@ -91,6 +91,7 @@ class game_data
         int         save_game() const;
         int         load_game();
         int         get_snake_length(int player) const;
+        void        set_player_snake_length(int player, int length);
         bool        get_achievement_snake50() const;
         int         get_apples_eaten() const;
         int         get_apples_normal_eaten() const;

--- a/game_data_board.cpp
+++ b/game_data_board.cpp
@@ -24,6 +24,16 @@ int game_data::get_map_value(int x, int y, int layer) const {
     return (this->_map.get(x, y, layer));
 }
 
+void game_data::set_player_snake_length(int player, int length) {
+    if (player < 0 || player >= 4)
+        return;
+    if (length < 0)
+        length = 0;
+    else if (length > MAX_SNAKE_LENGTH)
+        length = MAX_SNAKE_LENGTH;
+    this->_snake_length[player] = length;
+}
+
 void game_data::add_empty_cell(int x, int y) {
     size_t width = this->_map.get_width();
     int flat = y * static_cast<int>(width) + x;


### PR DESCRIPTION
## Summary
- add a clamped `set_player_snake_length` helper on `game_data`
- count player-one snake tiles when loading a custom map to keep lengths in sync and reset other players
- extend the bonus map regression tests to ensure the snake length resets to the map-defined size after game over

## Testing
- make tests

------
https://chatgpt.com/codex/tasks/task_e_68e040ff486c83318585219852a12456