### PR TITLE
Fix Raylib initialization frame handling

### DIFF
--- a/graphics_libs/src/RaylibGraphics.cpp
+++ b/graphics_libs/src/RaylibGraphics.cpp
@@ -66,9 +66,9 @@ int RaylibGraphics::initialize() {
         SetExitKey(KEY_NULL);
 
         // Clear any potential OpenGL errors from context switch
+        BeginDrawing();
         ClearBackground({0, 0, 0, 255}); // Use explicit Color struct
         EndDrawing(); // Force a frame to initialize graphics state
-        BeginDrawing();
 
     } catch (...) {
         setError("Exception during Raylib window initialization - likely OpenGL context conflict");


### PR DESCRIPTION
## Summary
- wrap the Raylib initialization warm-up clear in a BeginDrawing/EndDrawing pair
- remove the lingering BeginDrawing call so initialization leaves no open frame

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e0c4f3b7708331b8f5b99a1ce14f87