### PR TITLE
Highlight snake heads for all players across renderers

### DIFF
--- a/graphics_libs/src/NCursesGraphics.cpp
+++ b/graphics_libs/src/NCursesGraphics.cpp
@@ -375,10 +375,8 @@ char NCursesGraphics::getCharFromGameTile(int x, int y, const game_data& game) {
         return 'F';  // Fire food
     } else if (layer2Value == FROSTY_FOOD) {
         return 'I';  // Frosty food
-    } else if (layer2Value == SNAKE_HEAD_PLAYER_1) {
-        return '@'; // Snake head
-    } else if (layer2Value > SNAKE_HEAD_PLAYER_1) {
-        return 'o'; // Snake body
+    } else if (layer2Value >= SNAKE_HEAD_PLAYER_1) {
+        return (layer2Value % 1000000 == 1) ? '@' : 'o';
     }
 
     // Check layer 0 (terrain)
@@ -403,10 +401,8 @@ int NCursesGraphics::getColorFromGameTile(int x, int y, const game_data& game) {
         return COLOR_FIRE_FOOD;
     } else if (layer2Value == FROSTY_FOOD) {
         return COLOR_FROSTY_FOOD;
-    } else if (layer2Value == SNAKE_HEAD_PLAYER_1) {
-        return COLOR_SNAKE_HEAD;
-    } else if (layer2Value > SNAKE_HEAD_PLAYER_1) {
-        return COLOR_SNAKE_BODY;
+    } else if (layer2Value >= SNAKE_HEAD_PLAYER_1) {
+        return (layer2Value % 1000000 == 1) ? COLOR_SNAKE_HEAD : COLOR_SNAKE_BODY;
     }
 
     // Check layer 0 (terrain)

--- a/graphics_libs/src/OpenGLGraphics.cpp
+++ b/graphics_libs/src/OpenGLGraphics.cpp
@@ -338,10 +338,9 @@ void OpenGLGraphics::render(const game_data& game) {
                             drawRectangle(drawX + 2, drawY + 2, cellSize - 4, cellSize - 4, COLOR_FIRE_FOOD);
                         } else if (layer2Value == FROSTY_FOOD) {
                             drawRectangle(drawX + 2, drawY + 2, cellSize - 4, cellSize - 4, COLOR_FROSTY_FOOD);
-                        } else if (layer2Value == SNAKE_HEAD_PLAYER_1) {
-                            drawRectangle(drawX, drawY, cellSize, cellSize, head);
-                        } else if (layer2Value > SNAKE_HEAD_PLAYER_1) {
-                            drawRectangle(drawX, drawY, cellSize, cellSize, body);
+                        } else if (layer2Value >= SNAKE_HEAD_PLAYER_1) {
+                            const Color& color = (layer2Value % 1000000 == 1) ? head : body;
+                            drawRectangle(drawX, drawY, cellSize, cellSize, color);
                         } else {
                             // Check layer 0 (terrain)
                             int layer0Value = game.get_map_value(static_cast<int>(x), static_cast<int>(y), 0);

--- a/graphics_libs/src/SDL2Graphics.cpp
+++ b/graphics_libs/src/SDL2Graphics.cpp
@@ -357,11 +357,12 @@ void SDL2Graphics::render(const game_data& game) {
             } else if (layer2Value == FROSTY_FOOD) {
                 setDrawColor(COLOR_FROSTY_FOOD);
                 drawRect(pixelX + 2, pixelY + 2, cellSize - 4, cellSize - 4);
-            } else if (layer2Value == SNAKE_HEAD_PLAYER_1) {
-                setDrawColor(head);
-                drawRect(pixelX, pixelY, cellSize, cellSize);
-            } else if (layer2Value > SNAKE_HEAD_PLAYER_1) {
-                setDrawColor(body);
+            } else if (layer2Value >= SNAKE_HEAD_PLAYER_1) {
+                if (layer2Value % 1000000 == 1) {
+                    setDrawColor(head);
+                } else {
+                    setDrawColor(body);
+                }
                 drawRect(pixelX, pixelY, cellSize, cellSize);
             } else {
                 // Check layer 0 (terrain)


### PR DESCRIPTION
## Summary
- update the SDL2 and OpenGL render loops to detect all snake heads with a modulo check so every player gets the head color
- switch the NCurses glyph and color selection to use the same modulo logic for snake tiles

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e0d37869bc83318be973dc2280a379