### PR TITLE
Handle bonus rule reload fallback

### DIFF
--- a/GameEngine.hpp
+++ b/GameEngine.hpp
@@ -32,6 +32,10 @@ class GameEngine {
     int _defaultLibIndex;
     bool _libSlotAvailable[4];
     int _lastAppliedFPS;
+    int _baselineBoardWidth;
+    int _baselineBoardHeight;
+    bool _baselineWrapAroundEdges;
+    bool _baselineAdditionalFoodItems;
 
     void gameLoop();
     void handleInput(GameKey key, bool& shouldQuit);


### PR DESCRIPTION
## Summary
- store the baseline board configuration in the game engine so it can be restored
- reset menu settings and game data to the baseline configuration when reloading bonus rules fails

## Testing
- make tests

------
https://chatgpt.com/codex/tasks/task_e_68e0d523677c833189be0cebbcf58fd6