### PR TITLE
Use std::string for map name storage

### DIFF
--- a/game_data.hpp
+++ b/game_data.hpp
@@ -5,6 +5,7 @@
 #include "libft/Game/map3d.hpp"
 #include "libft/CPP_class/string_class.hpp"
 #include <vector>
+#include <string>
 
 #define GAME_TILE_EMPTY 0
 #define GAME_TILE_WALL 1
@@ -133,7 +134,7 @@ class game_data
         double      _moves_per_second;
         int         _additional_food_items;
         ft_string   _profile_name;
-        char        _map_name[256];
+        std::string _map_name;
         ft_map3d                                _map;
         ft_character                            _character;
         std::vector<t_coordinates>      _empty_cells;

--- a/game_data_core.cpp
+++ b/game_data_core.cpp
@@ -1,6 +1,4 @@
 #include "game_data.hpp"
-#include <cstring>
-
 int game_data::get_error() const {
     return (this->_error);
 }
@@ -106,15 +104,14 @@ const ft_string& game_data::get_profile_name() const {
 
 void game_data::set_map_name(const char *name) {
     if (!name) {
-        this->_map_name[0] = '\0';
+        this->_map_name.clear();
         return;
     }
-    std::strncpy(this->_map_name, name, sizeof(this->_map_name) - 1);
-    this->_map_name[sizeof(this->_map_name) - 1] = '\0';
+    this->_map_name = name;
 }
 
 const char *game_data::get_map_name() const {
-    return this->_map_name;
+    return this->_map_name.c_str();
 }
 
 int game_data::get_snake_length(int player) const {


### PR DESCRIPTION
## Summary
- replace the fixed-size map name buffer with a std::string while keeping the public API returning const char*
- update the map name setter/getter to work with the std::string and handle null inputs by clearing the value

## Testing
- make

------
https://chatgpt.com/codex/tasks/task_e_68e0eac6582c8331ab0f003724bfef61