### PR TITLE
Add ice tile colors across renderers

### DIFF
--- a/graphics_libs/include/OpenGLGraphics.hpp
+++ b/graphics_libs/include/OpenGLGraphics.hpp
@@ -90,6 +90,7 @@ class OpenGLGraphics : public IGraphicsLibrary {
     // Extra items/tiles
     static const Color COLOR_FIRE_FOOD;
     static const Color COLOR_FROSTY_FOOD;
+    static const Color COLOR_ICE_TILE;
     static const Color COLOR_FIRE_TILE;
 
     // Alternative palette
@@ -98,6 +99,7 @@ class OpenGLGraphics : public IGraphicsLibrary {
     static const Color ALT_COLOR_SNAKE_HEAD;
     static const Color ALT_COLOR_SNAKE_BODY;
     static const Color ALT_COLOR_FOOD;
+    static const Color ALT_COLOR_ICE_TILE;
     static const Color ALT_COLOR_TEXT;
 
     // Private helper methods

--- a/graphics_libs/include/RaylibGraphics.hpp
+++ b/graphics_libs/include/RaylibGraphics.hpp
@@ -44,6 +44,7 @@ class RaylibGraphics : public IGraphicsLibrary {
     static const Color COLOR_SELECTED_TEXT;
     static const Color COLOR_FIRE_FOOD;
     static const Color COLOR_FROSTY_FOOD;
+    static const Color COLOR_ICE_TILE;
     static const Color COLOR_FIRE_TILE;
 
     // Alternative palette
@@ -52,6 +53,7 @@ class RaylibGraphics : public IGraphicsLibrary {
     static const Color ALT_COLOR_SNAKE_HEAD;
     static const Color ALT_COLOR_SNAKE_BODY;
     static const Color ALT_COLOR_FOOD;
+    static const Color ALT_COLOR_ICE_TILE;
     static const Color ALT_COLOR_TEXT;
 
     bool _initialized;

--- a/graphics_libs/include/SDL2Graphics.hpp
+++ b/graphics_libs/include/SDL2Graphics.hpp
@@ -67,6 +67,7 @@ class SDL2Graphics : public IGraphicsLibrary {
     static const Color COLOR_FOOD;
     static const Color COLOR_FIRE_FOOD;
     static const Color COLOR_FROSTY_FOOD;
+    static const Color COLOR_ICE_TILE;
     static const Color COLOR_FIRE_TILE;
     static const Color COLOR_TEXT;
     static const Color COLOR_SELECTOR_BG;
@@ -78,6 +79,7 @@ class SDL2Graphics : public IGraphicsLibrary {
     static const Color ALT_COLOR_SNAKE_HEAD;
     static const Color ALT_COLOR_SNAKE_BODY;
     static const Color ALT_COLOR_FOOD;
+    static const Color ALT_COLOR_ICE_TILE;
     static const Color ALT_COLOR_TEXT;
 
     // Helper methods

--- a/graphics_libs/src/OpenGLGraphics.cpp
+++ b/graphics_libs/src/OpenGLGraphics.cpp
@@ -153,6 +153,7 @@ const OpenGLGraphics::Color OpenGLGraphics::COLOR_SELECTOR_BG(0.27f, 0.51f, 0.71
 const OpenGLGraphics::Color OpenGLGraphics::COLOR_SELECTED_TEXT(1.0f, 1.0f, 1.0f);  // White
 const OpenGLGraphics::Color OpenGLGraphics::COLOR_FIRE_FOOD(0.98f, 0.55f, 0.05f);
 const OpenGLGraphics::Color OpenGLGraphics::COLOR_FROSTY_FOOD(0.31f, 0.78f, 0.92f);
+const OpenGLGraphics::Color OpenGLGraphics::COLOR_ICE_TILE(0.55f, 0.78f, 0.94f);
 const OpenGLGraphics::Color OpenGLGraphics::COLOR_FIRE_TILE(0.78f, 0.20f, 0.20f);
 
 // Alternative palette
@@ -161,6 +162,7 @@ const OpenGLGraphics::Color OpenGLGraphics::ALT_COLOR_BORDER(0.70f, 0.63f, 0.35f
 const OpenGLGraphics::Color OpenGLGraphics::ALT_COLOR_SNAKE_HEAD(0.31f, 0.71f, 0.86f);
 const OpenGLGraphics::Color OpenGLGraphics::ALT_COLOR_SNAKE_BODY(0.16f, 0.47f, 0.71f);
 const OpenGLGraphics::Color OpenGLGraphics::ALT_COLOR_FOOD(0.92f, 0.51f, 0.14f);
+const OpenGLGraphics::Color OpenGLGraphics::ALT_COLOR_ICE_TILE(0.43f, 0.69f, 0.88f);
 const OpenGLGraphics::Color OpenGLGraphics::ALT_COLOR_TEXT(0.94f, 0.94f, 0.94f);
 
 OpenGLGraphics::OpenGLGraphics()
@@ -314,6 +316,7 @@ void OpenGLGraphics::render(const game_data& game) {
                 const Color& head   = useAlt ? ALT_COLOR_SNAKE_HEAD : COLOR_SNAKE_HEAD;
                 const Color& body   = useAlt ? ALT_COLOR_SNAKE_BODY : COLOR_SNAKE_BODY;
                 const Color& food   = useAlt ? ALT_COLOR_FOOD : COLOR_FOOD;
+                const Color& ice    = useAlt ? ALT_COLOR_ICE_TILE : COLOR_ICE_TILE;
 
                 // Draw game border (toggleable)
                 bool showBorders = _menuSystem && _menuSystem->getSettings().showBorders;
@@ -346,10 +349,12 @@ void OpenGLGraphics::render(const game_data& game) {
                             int layer0Value = game.get_map_value(static_cast<int>(x), static_cast<int>(y), 0);
                             if (layer0Value == GAME_TILE_WALL) {
                                 drawRectangle(drawX, drawY, cellSize, cellSize, border);
+                            } else if (layer0Value == GAME_TILE_ICE) {
+                                drawRectangle(drawX, drawY, cellSize, cellSize, ice);
                             } else if (layer0Value == GAME_TILE_FIRE) {
                                 drawRectangle(drawX, drawY, cellSize, cellSize, COLOR_FIRE_TILE);
                             }
-                            // Empty space and ice - no drawing needed (background already drawn)
+                            // Empty space - background already drawn
                         }
                     }
                 }

--- a/graphics_libs/src/RaylibGraphics.cpp
+++ b/graphics_libs/src/RaylibGraphics.cpp
@@ -17,6 +17,7 @@ const RaylibGraphics::Color RaylibGraphics::COLOR_SELECTOR_BG(70, 130, 180, 255)
 const RaylibGraphics::Color RaylibGraphics::COLOR_SELECTED_TEXT(255, 255, 255, 255);
 const RaylibGraphics::Color RaylibGraphics::COLOR_FIRE_FOOD(255, 140, 0, 255);
 const RaylibGraphics::Color RaylibGraphics::COLOR_FROSTY_FOOD(80, 200, 235, 255);
+const RaylibGraphics::Color RaylibGraphics::COLOR_ICE_TILE(140, 200, 240, 255);
 const RaylibGraphics::Color RaylibGraphics::COLOR_FIRE_TILE(200, 60, 40, 255);
 
 // Alternative palette
@@ -25,6 +26,7 @@ const RaylibGraphics::Color RaylibGraphics::ALT_COLOR_BORDER(180, 160, 90, 255);
 const RaylibGraphics::Color RaylibGraphics::ALT_COLOR_SNAKE_HEAD(80, 180, 220, 255);
 const RaylibGraphics::Color RaylibGraphics::ALT_COLOR_SNAKE_BODY(40, 120, 180, 255);
 const RaylibGraphics::Color RaylibGraphics::ALT_COLOR_FOOD(235, 130, 35, 255);
+const RaylibGraphics::Color RaylibGraphics::ALT_COLOR_ICE_TILE(110, 175, 225, 255);
 const RaylibGraphics::Color RaylibGraphics::ALT_COLOR_TEXT(240, 240, 240, 255);
 
 RaylibGraphics::RaylibGraphics()
@@ -100,6 +102,7 @@ void RaylibGraphics::render(const game_data& game) {
     const Color& head = useAlt ? ALT_COLOR_SNAKE_HEAD : COLOR_SNAKE_HEAD;
     const Color& body = useAlt ? ALT_COLOR_SNAKE_BODY : COLOR_SNAKE_BODY;
     const Color& food = useAlt ? ALT_COLOR_FOOD : COLOR_FOOD;
+    const Color& ice = useAlt ? ALT_COLOR_ICE_TILE : COLOR_ICE_TILE;
     const Color& text = useAlt ? ALT_COLOR_TEXT : COLOR_TEXT;
 
     BeginDrawing();
@@ -143,7 +146,7 @@ void RaylibGraphics::render(const game_data& game) {
                 if (l0 == GAME_TILE_WALL)
                     DrawRectangle(px, py, cellSize, cellSize, {border.r, border.g, border.b, border.a});
                 else if (l0 == GAME_TILE_ICE)
-                    DrawRectangle(px, py, cellSize, cellSize, {bg.r, bg.g, bg.b, bg.a});
+                    DrawRectangle(px, py, cellSize, cellSize, {ice.r, ice.g, ice.b, ice.a});
                 else if (l0 == GAME_TILE_FIRE)
                     DrawRectangle(px, py, cellSize, cellSize, {COLOR_FIRE_TILE.r, COLOR_FIRE_TILE.g, COLOR_FIRE_TILE.b, COLOR_FIRE_TILE.a});
             }

--- a/graphics_libs/src/SDL2Graphics.cpp
+++ b/graphics_libs/src/SDL2Graphics.cpp
@@ -154,6 +154,7 @@ const SDL2Graphics::Color SDL2Graphics::COLOR_TEXT(255, 255, 255);     // White
 // Extra tiles/foods
 const SDL2Graphics::Color SDL2Graphics::COLOR_FIRE_FOOD(255, 140, 0);   // Bright orange for fire food
 const SDL2Graphics::Color SDL2Graphics::COLOR_FROSTY_FOOD(80, 200, 235);// Cyan for frosty food
+const SDL2Graphics::Color SDL2Graphics::COLOR_ICE_TILE(140, 200, 240);   // Pale blue for ice tile
 const SDL2Graphics::Color SDL2Graphics::COLOR_FIRE_TILE(200, 60, 40);    // Red for fire tile
 
 // Alternative palette
@@ -162,6 +163,7 @@ const SDL2Graphics::Color SDL2Graphics::ALT_COLOR_BORDER(180, 160, 90);    // Sa
 const SDL2Graphics::Color SDL2Graphics::ALT_COLOR_SNAKE_HEAD(80, 180, 220); // Cyan head
 const SDL2Graphics::Color SDL2Graphics::ALT_COLOR_SNAKE_BODY(40, 120, 180); // Blue body
 const SDL2Graphics::Color SDL2Graphics::ALT_COLOR_FOOD(235, 130, 35);      // Orange
+const SDL2Graphics::Color SDL2Graphics::ALT_COLOR_ICE_TILE(110, 175, 225);  // Muted blue for ice tile
 const SDL2Graphics::Color SDL2Graphics::ALT_COLOR_TEXT(240, 240, 240);     // Near white
 
 // Additional colors for better UI
@@ -313,6 +315,7 @@ void SDL2Graphics::render(const game_data& game) {
     const Color& head = useAlt ? ALT_COLOR_SNAKE_HEAD : COLOR_SNAKE_HEAD;
     const Color& body = useAlt ? ALT_COLOR_SNAKE_BODY : COLOR_SNAKE_BODY;
     const Color& food = useAlt ? ALT_COLOR_FOOD : COLOR_FOOD;
+    const Color& ice = useAlt ? ALT_COLOR_ICE_TILE : COLOR_ICE_TILE;
     const Color& text = useAlt ? ALT_COLOR_TEXT : COLOR_TEXT;
 
     // Clear screen with background color
@@ -371,7 +374,7 @@ void SDL2Graphics::render(const game_data& game) {
                     setDrawColor(border);
                     drawRect(pixelX, pixelY, cellSize, cellSize);
                 } else if (layer0Value == GAME_TILE_ICE) {
-                    setDrawColor(bg);
+                    setDrawColor(ice);
                     drawRect(pixelX, pixelY, cellSize, cellSize);
                 } else if (layer0Value == GAME_TILE_FIRE) {
                     setDrawColor(COLOR_FIRE_TILE);


### PR DESCRIPTION
## Summary
- add dedicated ice tile colors for ice terrain across the SDL2, Raylib, and OpenGL backends
- route the alternative color palette settings to the new ice colors and ensure OpenGL renders the tiles

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e0ee065b1883318fc42a6505635058