### PR TITLE
Track snake segments for efficient movement updates

### DIFF
--- a/Test/movement_tests.cpp
+++ b/Test/movement_tests.cpp
@@ -1,6 +1,7 @@
 #include "../game_data.hpp"
 
 #include <cassert>
+#include <chrono>
 #include <iostream>
 
 static void clear_board(game_data &data)
@@ -14,12 +15,14 @@ static void clear_board(game_data &data)
             data.set_map_value(static_cast<int>(x), static_cast<int>(y), 2, 0);
         }
     }
+    data.sync_snake_segments_from_map();
 }
 
 static void place_head(game_data &data, int head_value, int x, int y)
 {
     data.set_map_value(x, y, 0, GAME_TILE_EMPTY);
     data.set_map_value(x, y, 2, head_value);
+    data.sync_snake_segments_from_map();
 }
 
 static void place_wall(game_data &data, int x, int y)
@@ -40,6 +43,56 @@ static void expect_valid_move(game_data &data, int head_value, const char *label
     if (result != 0)
         std::cerr << label << " should have been valid but returned " << result << '\n';
     assert(result == 0);
+}
+
+static void test_high_length_snake_moves()
+{
+    const int width = 1500;
+    const int height = 5;
+    const int snakeLength = 1200;
+    const int movesToRun = 200;
+    const int row = height / 2;
+
+    game_data data(width, height);
+    clear_board(data);
+
+    int head_x = snakeLength + 5;
+    for (int i = 0; i < snakeLength; ++i)
+    {
+        int x = head_x - i;
+        data.set_map_value(x, row, 0, GAME_TILE_EMPTY);
+        data.set_map_value(x, row, 2, SNAKE_HEAD_PLAYER_1 + i);
+    }
+    data.set_player_snake_length(0, snakeLength);
+    data.sync_snake_segments_from_map();
+
+    data.set_direction_moving(0, DIRECTION_RIGHT);
+
+    double step = 1.0 / data.get_moves_per_second();
+    auto start = std::chrono::steady_clock::now();
+    for (int i = 0; i < movesToRun; ++i)
+    {
+        assert(data.test_is_valid_move(SNAKE_HEAD_PLAYER_1) == 0);
+        int result = data.update_game_map(step);
+        assert(result == 0);
+    }
+    auto end = std::chrono::steady_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+    assert(duration.count() < 1500);
+
+    assert(data.get_snake_length(0) == snakeLength);
+    t_coordinates head = data.get_head_coordinate(SNAKE_HEAD_PLAYER_1);
+    assert(head.x == head_x + movesToRun);
+    assert(head.y == row);
+
+    int firstTailX = head_x - snakeLength + 1;
+    for (int moveIndex = 0; moveIndex < movesToRun; ++moveIndex)
+    {
+        int x = firstTailX + moveIndex;
+        assert(data.get_map_value(x, row, 2) == 0);
+    }
+
+    std::cout << "High length movement test duration: " << duration.count() << "ms\n";
 }
 
 int main()
@@ -70,6 +123,8 @@ int main()
     ensure_empty(data, 1, 3);
     data.set_direction_moving(3, DIRECTION_LEFT);
     expect_valid_move(data, SNAKE_HEAD_PLAYER_4, "player 4 move");
+
+    test_high_length_snake_moves();
 
     std::cout << "Movement tests passed" << std::endl;
     return 0;

--- a/file_utils.cpp
+++ b/file_utils.cpp
@@ -307,6 +307,7 @@ int load_rules_into_game_data(game_data &data, const game_rules &rules) {
                 data.set_map_value(fx2, fy2, 0, GAME_TILE_FIRE);
             }
         }
+        data.sync_snake_segments_from_map();
     }
     return 0;
 }

--- a/game_data.hpp
+++ b/game_data.hpp
@@ -6,6 +6,7 @@
 #include "libft/CPP_class/string_class.hpp"
 #include <vector>
 #include <string>
+#include <deque>
 
 #define GAME_TILE_EMPTY 0
 #define GAME_TILE_WALL 1
@@ -104,6 +105,8 @@ class game_data
         int         get_tile_frosty_steps() const;
         int         get_tile_fire_steps() const;
 
+        void        sync_snake_segments_from_map();
+
     // Testing method - exposes private is_valid_move for unit tests
     int test_is_valid_move(int player_head);
 
@@ -113,6 +116,9 @@ class game_data
         void        add_empty_cell(int x, int y);
         void        remove_empty_cell(int x, int y);
         void        initialize_empty_cells();
+        void        apply_snake_segments(int player, const std::vector<t_coordinates> &segments);
+        void        rebuild_snake_segments_from_map(int player);
+        void        write_snake_to_map(int player);
 
         int         is_valid_move(int player_head);
         bool        advance_wrap_target(int direction, int &target_x, int &target_y) const;
@@ -139,6 +145,7 @@ class game_data
         ft_character                            _character;
         std::vector<t_coordinates>      _empty_cells;
         std::vector<int>                _empty_cell_indices;
+        std::deque<t_coordinates>       _snake_segments[4];
 };
 
 #endif // GAME_DATA_HPP

--- a/game_data_io.cpp
+++ b/game_data_io.cpp
@@ -418,6 +418,7 @@ int game_data::load_game() {
 
     int actualCountPlaced = count_player_one_segments();
     this->set_player_snake_length(0, actualCountPlaced);
+    this->sync_snake_segments_from_map();
 
     json_free_groups(root);
     return (0);


### PR DESCRIPTION
## Summary
- maintain per-player snake segment deques and helper utilities so resets and map/rule loading keep the segment lists synchronized
- refactor movement updates to push/pop from the deque, clear the tail only when needed, and rewrite map values directly from the stored segments
- add a high-length regression test that drives `update_game_map` to verify the new logic stays performant

## Testing
- make tests

------
https://chatgpt.com/codex/tasks/task_e_68e0ef2e17a48331ba3ff392cf8aeb0e