### PR TITLE
Reset game state when returning to menu

### DIFF
--- a/GameEngine.cpp
+++ b/GameEngine.cpp
@@ -340,6 +340,8 @@ void GameEngine::handleInput(GameKey key, bool& shouldQuit) {
         case GameKey::QUIT:
             // Go back to main menu instead of quitting directly
             _menuSystem.setState(MenuState::MAIN_MENU);
+            _gameStarted = false;
+            prepareBoardForNextGame();
             break;
         case GameKey::NONE:
         default:
@@ -380,6 +382,10 @@ void GameEngine::handleGameOver() {
     _menuSystem.setState(MenuState::GAME_OVER);
     _gameStarted = false;
 
+    prepareBoardForNextGame();
+}
+
+void GameEngine::prepareBoardForNextGame() {
     if (_usingBonusMap && _cachedBonusRules.has_value()) {
         if (load_rules_into_game_data(_gameData, *_cachedBonusRules) == 0) {
             GameSettings settings = _menuSystem.getSettings();
@@ -414,7 +420,6 @@ void GameEngine::handleGameOver() {
 
     _gameData.reset_board();
 }
-
 void GameEngine::renderGame() {
     IGraphicsLibrary* currentLib = _libraryManager.getCurrentLibrary();
     if (currentLib) {

--- a/GameEngine.hpp
+++ b/GameEngine.hpp
@@ -47,6 +47,7 @@ class GameEngine {
     void switchGraphicsLibrary(int libraryIndex);
     void performIntermediateSwitch(int intermediateIndex, int finalIndex);
     void handleGameOver();
+    void prepareBoardForNextGame();
     void setError(const std::string& error);
     void clearError();
 


### PR DESCRIPTION
## Summary
- reset the `_gameStarted` flag when exiting the in-game menu and refresh the board state for the next round
- reuse a new helper to prepare the board after game over or menu exits, keeping bonus map settings in sync

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0febfa46c8331a1d540d9367c8981