### PR TITLE
Ensure ESC from game over returns to menu

### DIFF
--- a/MenuSystem.cpp
+++ b/MenuSystem.cpp
@@ -137,7 +137,7 @@ void MenuSystem::goBack() {
             setState(MenuState::MAIN_MENU);
             break;
         case MenuState::GAME_OVER:
-            setState(MenuState::EXIT_REQUESTED);
+            setState(MenuState::MAIN_MENU);
             break;
         default:
             break;


### PR DESCRIPTION
## Summary
- route game-over escape handling back to the main menu instead of exiting the application
- verified the graphics overlays already instruct players that ESC returns to the main menu, so no text updates were required

## Testing
- not run (manual confirmation)


------
https://chatgpt.com/codex/tasks/task_e_68e103e98cb883318f055d78b8b64781