### PR TITLE
Add shared font path cache for SDL2 and OpenGL renderers

### DIFF
--- a/graphics_libs/Makefile
+++ b/graphics_libs/Makefile
@@ -20,9 +20,10 @@ RAYLIB_LIB = $(OUT_DIR)/lib_raylib.so
 ALL_LIBS = $(NCURSES_LIB) $(SDL2_LIB) $(OPENGL_LIB) $(RAYLIB_LIB)
 
 # Sources (moved to src/)
-SDL2_SOURCES = src/SDL2Graphics.cpp
+COMMON_SOURCES = src/FontCache.cpp
+SDL2_SOURCES = src/SDL2Graphics.cpp $(COMMON_SOURCES)
 NCURSES_SOURCES = src/NCursesGraphics.cpp
-OPENGL_SOURCES = src/OpenGLGraphics.cpp
+OPENGL_SOURCES = src/OpenGLGraphics.cpp $(COMMON_SOURCES)
 RAYLIB_SOURCES = src/RaylibGraphics.cpp
 
 # Headers (moved to include/)

--- a/graphics_libs/include/FontCache.hpp
+++ b/graphics_libs/include/FontCache.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <optional>
+#include <string>
+
+namespace graphics::font_cache {
+
+// Retrieve the cached font path if one has been resolved previously.
+const std::optional<std::string>& get();
+
+// Store a resolved font path for reuse across graphics libraries.
+void set(const std::string& path);
+
+// Clear the cached path (primarily for error handling scenarios).
+void reset();
+
+} // namespace graphics::font_cache
+

--- a/graphics_libs/src/FontCache.cpp
+++ b/graphics_libs/src/FontCache.cpp
@@ -1,0 +1,25 @@
+#include "FontCache.hpp"
+
+namespace graphics::font_cache {
+
+namespace {
+std::optional<std::string>& cachedFontPath() {
+    static std::optional<std::string> s_cachedFontPath;
+    return s_cachedFontPath;
+}
+} // namespace
+
+const std::optional<std::string>& get() {
+    return cachedFontPath();
+}
+
+void set(const std::string& path) {
+    cachedFontPath() = path;
+}
+
+void reset() {
+    cachedFontPath().reset();
+}
+
+} // namespace graphics::font_cache
+


### PR DESCRIPTION
## Summary
- add a shared font-path cache utility that persists the resolved font for reuse
- update SDL2 and OpenGL font initialization to reuse the cache and stop scanning once a usable font is located
- include the common cache source when building the graphics libraries

## Testing
- make graphics_libs

------
https://chatgpt.com/codex/tasks/task_e_68e10db6745483319bf281e0544c637a